### PR TITLE
Exodus Tweaks for Playtest

### DIFF
--- a/maps/exodus/exodus-2.dmm
+++ b/maps/exodus/exodus-2.dmm
@@ -189,10 +189,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/floor/tiled/steel_grid,
 /area/exodus/security/range)
-"aaA" = (
-/obj/structure/sign/warning/secure_area,
-/turf/wall/prepainted,
-/area/space)
 "aaB" = (
 /obj/machinery/camera/network/security{
 	c_tag = "Armory Exterior";
@@ -353,6 +349,7 @@
 /obj/item/target,
 /obj/item/target,
 /obj/item/target,
+/obj/machinery/light,
 /turf/floor/tiled/steel_grid,
 /area/exodus/security/range)
 "aaW" = (
@@ -375,9 +372,6 @@
 /area/exodus/security/range)
 "aaY" = (
 /obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
@@ -502,9 +496,12 @@
 /turf/floor/plating,
 /area/exodus/security/range)
 "abr" = (
-/obj/structure/sign/warning/high_voltage,
-/turf/wall/r_wall/prepainted,
-/area/exodus/maintenance/foresolar)
+/obj/structure/flora/pottedplant/unusual{
+	name = "Steve";
+	desc = "This is an unusual plant. It's bulbous ends emit a soft blue light. The name Steve is written in black marker on the pot."
+	},
+/turf/floor/bluegrid,
+/area/exodus/turret_protected/ai)
 "abs" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -520,6 +517,10 @@
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
+	},
+/obj/structure/sign/warning/high_voltage{
+	dir = 4;
+	pixel_x = -32
 	},
 /turf/floor/plating,
 /area/exodus/maintenance/security_port)
@@ -697,12 +698,11 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/security/range)
 "abI" = (
-/obj/machinery/light,
-/obj/effect/floor_decal/industrial/warning{
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/floor/tiled/steel_grid,
-/area/exodus/security/range)
+/turf/floor/tiled/white,
+/area/exodus/medical/sleeper)
 "abJ" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -1163,17 +1163,6 @@
 	},
 /turf/floor/plating,
 /area/exodus/maintenance/foresolar)
-"acC" = (
-/obj/structure/sign/plaque/golden,
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
-/obj/effect/wallframe_spawn/reinforced/polarized,
-/turf/floor/plating,
-/area/exodus/crew_quarters/heads/hos)
 "acD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -1261,15 +1250,15 @@
 /obj/item/screwdriver{
 	pixel_y = 15
 	},
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -29;
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/security/main)
@@ -1355,8 +1344,8 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	pixel_y = 20
+/obj/structure/noticeboard{
+	pixel_y = 32
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/security/meeting)
@@ -1471,10 +1460,11 @@
 /turf/floor/plating,
 /area/exodus/maintenance/security_starboard)
 "adj" = (
-/obj/structure/sign/warning/airlock{
-	pixel_y = 32
-	},
 /obj/machinery/space_heater,
+/obj/structure/sign/warning/airlock{
+	pixel_x = 32;
+	dir = 8
+	},
 /turf/floor/plating,
 /area/exodus/maintenance/security_starboard)
 "adk" = (
@@ -1518,9 +1508,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/vending/snack,
 /obj/effect/floor_decal/corner/red{
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/vending/snack{
+	dir = 8
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/security/meeting)
@@ -1605,11 +1600,13 @@
 /turf/floor/tiled/dark,
 /area/exodus/security/armoury)
 "adA" = (
-/obj/machinery/flasher/portable,
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/flasher/portable{
+	directional_offset = null
+	},
 /turf/floor/tiled/dark,
 /area/exodus/security/armoury)
 "adB" = (
@@ -1619,7 +1616,6 @@
 /turf/floor/plating,
 /area/exodus/maintenance/security_starboard)
 "adC" = (
-/obj/machinery/flasher/portable,
 /obj/machinery/power/apc{
 	name = "south bump";
 	pixel_y = -24
@@ -1629,6 +1625,9 @@
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/light,
+/obj/machinery/flasher/portable{
+	directional_offset = null
+	},
 /turf/floor/tiled/dark,
 /area/exodus/security/armoury)
 "adD" = (
@@ -1783,14 +1782,12 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/security/meeting)
 "adW" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/noticeboard{
-	default_pixel_x = 32
-	},
 /obj/effect/floor_decal/corner/red{
 	dir = 4
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = 22
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/security/meeting)
@@ -1845,12 +1842,13 @@
 /turf/floor/plating,
 /area/exodus/maintenance/security_port)
 "aee" = (
-/obj/structure/sign/warning/internals_required{
-	pixel_x = 32;
-	pixel_y = 32
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/status_display/supply_display{
+	pixel_y = -32;
+	dir = 1
 	},
 /turf/floor/plating,
-/area/exodus/maintenance/security_starboard)
+/area/exodus/quartermaster/office)
 "aef" = (
 /obj/structure/table,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -1899,9 +1897,6 @@
 /turf/floor/tiled/dark,
 /area/exodus/security/tactical)
 "aei" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/closet/bombclosetsecurity,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/alarm{
@@ -1927,8 +1922,10 @@
 /area/exodus/security/main)
 "aek" = (
 /obj/machinery/light,
-/obj/machinery/flasher/portable,
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/flasher/portable{
+	directional_offset = null
+	},
 /turf/floor/tiled/dark,
 /area/exodus/security/armoury)
 "ael" = (
@@ -1978,8 +1975,7 @@
 	department = "Security";
 	name = "Security RC";
 	pixel_x = 32;
-	dir = 4;
-	
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 4
@@ -2020,9 +2016,6 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/security/main)
 "aeu" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/window/reinforced,
 /obj/structure/table,
 /obj/effect/floor_decal/corner/red{
@@ -2730,6 +2723,9 @@
 /area/exodus/maintenance/security_port)
 "afV" = (
 /obj/random/closet,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/floor/plating,
 /area/exodus/maintenance/security_starboard)
 "afW" = (
@@ -2775,6 +2771,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/light/small,
 /turf/floor/plating,
 /area/exodus/maintenance/security_port)
 "agd" = (
@@ -2919,6 +2916,9 @@
 	name = "Weapons locker"
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/floor/tiled/dark,
 /area/exodus/security/armoury)
 "agt" = (
@@ -3062,7 +3062,6 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/security/main)
 "agI" = (
-/obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -3261,8 +3260,7 @@
 	department = "Head of Security's Desk";
 	name = "Head of Security RC";
 	pixel_y = 32;
-	dir = 1;
-	
+	dir = 1
 	},
 /turf/floor/tiled/dark,
 /area/exodus/crew_quarters/heads/hos)
@@ -3409,9 +3407,6 @@
 	name = "Weapons locker"
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/item/gun/energy/taser,
 /obj/item/gun/energy/taser,
 /obj/item/gun/energy/taser,
@@ -3625,6 +3620,9 @@
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -22
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/security/brig/interrogation)
@@ -4068,9 +4066,6 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/security/brig/interrogation)
 "aiY" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -4212,21 +4207,15 @@
 /turf/floor/tiled/dark,
 /area/exodus/security/warden)
 "ajk" = (
-/obj/machinery/light/small{
+/obj/structure/bed/chair/wood/walnut{
+	dir = 8
+	},
+/obj/machinery/status_display{
+	pixel_y = -32;
 	dir = 1
 	},
-/obj/machinery/network/relay,
-/turf/floor/plating,
-/area/exodus/maintenance/security_starboard)
-"ajl" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/floor/plating,
-/area/exodus/maintenance/security_port)
+/turf/floor/wood/walnut,
+/area/exodus/crew_quarters/bar)
 "ajm" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -4456,6 +4445,9 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "0-4"
+	},
+/obj/structure/sign/warning/high_voltage{
+	pixel_y = 32
 	},
 /turf/floor/plating,
 /area/exodus/security/prison)
@@ -6241,10 +6233,6 @@
 	},
 /turf/floor/plating,
 /area/exodus/security/prison)
-"and" = (
-/obj/structure/sign/warning/high_voltage,
-/turf/wall/prepainted,
-/area/exodus/maintenance/substation/security)
 "ane" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6400,6 +6388,10 @@
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
+/obj/structure/sign/warning/high_voltage{
+	dir = 8;
+	pixel_x = 32
+	},
 /turf/floor/plating,
 /area/exodus/maintenance/security_starboard)
 "ant" = (
@@ -6755,8 +6747,7 @@
 	department = "Security";
 	name = "Security RC";
 	pixel_x = 32;
-	dir = 4;
-	
+	dir = 4
 	},
 /turf/floor/lino,
 /area/exodus/security/detectives_office)
@@ -6855,7 +6846,7 @@
 /area/exodus/solar/auxport)
 "aoq" = (
 /turf/unsimulated/mask,
-/area/space)
+/area/exodus/maintenance/security_port)
 "aor" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -6988,10 +6979,6 @@
 /obj/effect/wallframe_spawn/reinforced,
 /turf/floor/plating,
 /area/exodus/crew_quarters/fitness)
-"aoF" = (
-/obj/structure/sign/warning/high_voltage,
-/turf/wall/r_wall/prepainted,
-/area/exodus/security/prison)
 "aoG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/floor/tiled/steel_grid,
@@ -7168,8 +7155,7 @@
 	department = "Internal Affairs";
 	name = "Internal Affairs RC";
 	pixel_x = 32;
-	dir = 4;
-	
+	dir = 4
 	},
 /turf/floor/tiled/dark,
 /area/exodus/lawoffice)
@@ -7243,16 +7229,17 @@
 /turf/floor/airless,
 /area/exodus/solar/auxport)
 "apl" = (
+/obj/structure/cable,
+/obj/effect/engine_setup/smes,
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Engine - Main";
-	charge = 1e+007;
+	charge = 2.5e+005;
 	input_attempt = 1;
 	input_level = 1e+006;
 	output_attempt = 1;
-	output_level = 1e+006
+	output_level = 1e+006;
+	uncreated_component_parts = list(/obj/item/stock_parts/smes_coil/super_capacity = 4)
 	},
-/obj/structure/cable,
-/obj/effect/engine_setup/smes,
 /turf/floor/plating,
 /area/exodus/engineering/engine_smes)
 "apm" = (
@@ -8210,9 +8197,6 @@
 /area/exodus/security/lobby)
 "are" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -22
@@ -8522,6 +8506,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/floor/plating,
 /area/exodus/maintenance/dormitory)
 "arK" = (
@@ -9449,8 +9436,7 @@
 /obj/machinery/network/requests_console{
 	department = "Crew Quarters";
 	pixel_y = 32;
-	dir = 1;
-	
+	dir = 1
 	},
 /turf/floor/tiled/white/monotile,
 /area/exodus/crew_quarters/sleep/cryo)
@@ -9507,6 +9493,9 @@
 /obj/structure/cable/green{
 	icon_state = "0-2"
 	},
+/obj/structure/sign/warning/secure_area{
+	pixel_y = 32
+	},
 /turf/floor/plating,
 /area/exodus/hallway/primary/port)
 "atV" = (
@@ -9518,7 +9507,7 @@
 /area/exodus/crew_quarters/sleep/cryo)
 "atW" = (
 /turf/floor/reinforced,
-/area/space)
+/area/exodus/crew_quarters/fitness)
 "atX" = (
 /obj/effect/paint_stripe/blue,
 /turf/wall/titanium,
@@ -10196,11 +10185,12 @@
 /turf/floor/carpet,
 /area/exodus/crew_quarters/sleep/bedrooms)
 "avy" = (
-/obj/structure/sign/directions/pods{
-	dir = 1
+/obj/machinery/status_display{
+	pixel_x = -32;
+	dir = 8
 	},
-/turf/wall/prepainted,
-/area/exodus/hallway/secondary/entry/pods)
+/turf/floor/tiled/white,
+/area/exodus/medical/medbay)
 "avz" = (
 /obj/machinery/cryopod,
 /obj/item/radio/intercom{
@@ -10309,6 +10299,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/sign/directions/pods{
+	dir = 1;
+	pixel_y = 32
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/secondary/entry/pods)
@@ -10442,6 +10436,9 @@
 	},
 /obj/machinery/camera/network/exodus{
 	c_tag = "Arrivals North"
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/secondary/entry/fore)
@@ -10780,6 +10777,10 @@
 "awJ" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
+	},
+/obj/structure/sign/directions/pods{
+	dir = 1;
+	pixel_y = 32
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/secondary/entry/pods)
@@ -11155,12 +11156,6 @@
 "axA" = (
 /turf/floor/tiled/freezer,
 /area/exodus/crew_quarters/fitness)
-"axB" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/structure/sign/warning/secure_area,
-/obj/machinery/door/firedoor,
-/turf/floor/plating,
-/area/exodus/hallway/primary/central_one)
 "axC" = (
 /obj/machinery/door/airlock/glass{
 	name = "Holodeck"
@@ -12683,6 +12678,9 @@
 	pixel_y = 4
 	},
 /obj/item/box/ids,
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/bridge)
 "aAK" = (
@@ -12856,6 +12854,9 @@
 /obj/item/flash,
 /obj/item/flash,
 /obj/item/aicard,
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/bridge)
 "aBa" = (
@@ -12880,7 +12881,9 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
 /turf/floor/tiled/white,
 /area/exodus/research/xenobiology)
 "aBc" = (
@@ -13245,8 +13248,7 @@
 /obj/machinery/network/requests_console{
 	department = "EVA";
 	pixel_x = -32;
-	dir = 8;
-	
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 8
@@ -13727,9 +13729,13 @@
 /turf/floor/tiled/freezer,
 /area/exodus/crew_quarters/toilet)
 "aDe" = (
-/obj/structure/sign/warning/high_voltage,
-/turf/wall/prepainted,
-/area/exodus/maintenance/substation/civilian_east)
+/obj/structure/grille,
+/obj/structure/sign/warning/docking_area{
+	pixel_y = -32;
+	dir = 1
+	},
+/turf/floor/airless,
+/area/exodus/maintenance/exterior)
 "aDf" = (
 /obj/abstract/landmark{
 	name = "xeno_spawn";
@@ -13916,9 +13922,6 @@
 /area/exodus/crew_quarters/fitness)
 "aDz" = (
 /obj/structure/closet/secure_closet/security,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/item/flashlight/flare,
 /obj/effect/floor_decal/corner/red/three_quarters{
 	dir = 8
@@ -13972,6 +13975,9 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 5
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/floor/tiled/dark,
 /area/exodus/security/checkpoint2)
 "aDJ" = (
@@ -14008,8 +14014,7 @@
 /obj/machinery/network/requests_console{
 	department = "Tool Storage";
 	pixel_y = 32;
-	dir = 1;
-	
+	dir = 1
 	},
 /obj/random/tech_supply,
 /obj/random/tech_supply,
@@ -14136,9 +14141,9 @@
 /turf/floor/plating,
 /area/exodus/maintenance/auxsolarstarboard)
 "aDZ" = (
-/obj/structure/sign/warning/high_voltage,
-/turf/wall/r_wall/prepainted,
-/area/exodus/maintenance/auxsolarport)
+/obj/machinery/smartfridge,
+/turf/floor/tiled/steel_grid,
+/area/exodus/hydroponics)
 "aEa" = (
 /obj/item/coin/silver{
 	pixel_x = 7;
@@ -14440,6 +14445,9 @@
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
+	},
+/obj/structure/sign/warning/high_voltage{
+	pixel_y = 32
 	},
 /turf/floor/plating,
 /area/exodus/maintenance/library)
@@ -14782,6 +14790,9 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
+/obj/structure/sign/warning/high_voltage{
+	pixel_y = 32
+	},
 /turf/floor/plating,
 /area/exodus/maintenance/arrivals)
 "aFi" = (
@@ -14997,15 +15008,11 @@
 /obj/machinery/network/requests_console{
 	department = "Security";
 	pixel_y = 32;
-	dir = 1;
-	
+	dir = 1
 	},
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/red/three_quarters{
@@ -15046,9 +15053,6 @@
 /turf/floor/tiled/dark,
 /area/exodus/ai_monitored/storage/eva)
 "aFL" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -15101,6 +15105,10 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
+/obj/structure/sign/warning/high_voltage{
+	dir = 8;
+	pixel_x = 32
+	},
 /turf/floor/plating,
 /area/exodus/maintenance/dormitory)
 "aFR" = (
@@ -15156,6 +15164,10 @@
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
+	},
+/obj/structure/sign/warning/high_voltage{
+	dir = 4;
+	pixel_x = -32
 	},
 /turf/floor/tiled/dark,
 /area/exodus/crew_quarters/sleep)
@@ -15443,9 +15455,12 @@
 /turf/floor/tiled/dark/monotile,
 /area/shuttle/arrival/station)
 "aGy" = (
-/obj/structure/sign/warning/high_voltage,
-/turf/wall/r_wall/prepainted,
-/area/exodus/maintenance/auxsolarstarboard)
+/obj/structure/grille,
+/obj/structure/sign/warning/docking_area{
+	pixel_y = 32
+	},
+/turf/floor/airless,
+/area/exodus/maintenance/exterior)
 "aGz" = (
 /obj/structure/safe,
 /obj/item/clothing/jumpsuit/yellow,
@@ -15911,14 +15926,10 @@
 /turf/floor/lino,
 /area/exodus/chapel/office)
 "aHx" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/machinery/network/requests_console{
 	department = "Chapel";
 	pixel_y = 32;
-	dir = 1;
-	
+	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/floor/lino,
@@ -16203,6 +16214,9 @@
 	},
 /obj/machinery/power/terminal,
 /obj/effect/floor_decal/industrial/warning,
+/obj/structure/sign/warning/high_voltage{
+	pixel_y = 32
+	},
 /turf/floor/plating,
 /area/exodus/maintenance/substation/civilian_west)
 "aHV" = (
@@ -16426,10 +16440,6 @@
 	},
 /turf/floor/plating,
 /area/exodus/maintenance/bar)
-"aIo" = (
-/obj/structure/sign/warning/docking_area,
-/turf/wall/r_wall/prepainted,
-/area/exodus/maintenance/exterior)
 "aIp" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -16563,13 +16573,28 @@
 /turf/floor/tiled/dark/monotile,
 /area/shuttle/arrival/station)
 "aIE" = (
-/obj/structure/sign/double/map/left,
-/turf/wall/prepainted,
-/area/exodus/hallway/secondary/entry/starboard)
+/obj/effect/floor_decal/corner/lime{
+	dir = 10
+	},
+/obj/structure/sign/department/star_of_life{
+	name = "Medbay";
+	pixel_y = -32
+	},
+/turf/floor/tiled/steel_grid,
+/area/exodus/hallway/primary/starboard)
 "aIF" = (
-/obj/structure/sign/double/map/right,
-/turf/wall/prepainted,
-/area/exodus/hallway/secondary/entry/starboard)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 10
+	},
+/obj/structure/sign/department/star_of_life{
+	name = "Medbay";
+	pixel_y = -32
+	},
+/turf/floor/tiled/steel_grid,
+/area/exodus/hallway/primary/starboard)
 "aIG" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -16644,9 +16669,12 @@
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/hallway/primary/central_two)
 "aIQ" = (
-/obj/structure/sign/warning/secure_area,
-/turf/wall/r_wall/prepainted,
-/area/exodus/security/nuke_storage)
+/obj/effect/floor_decal/corner/red{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/floor/tiled/steel_grid,
+/area/exodus/security/meeting)
 "aIR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16740,9 +16768,6 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/crew_quarters/bar/cabin)
 "aJc" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/closet/l3closet/scientist,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -16857,9 +16882,11 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/secondary/entry/port)
 "aJu" = (
-/obj/structure/sign/warning/high_voltage,
-/turf/wall/r_wall/prepainted,
-/area/exodus/maintenance/substation/command)
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/floor/tiled/white,
+/area/exodus/research/robotics)
 "aJv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -17049,6 +17076,9 @@
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
 	},
+/obj/structure/sign/double/map/left{
+	pixel_y = 32
+	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/secondary/entry/starboard)
 "aJP" = (
@@ -17076,6 +17106,9 @@
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
+	},
+/obj/structure/sign/double/map/right{
+	pixel_y = 32
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/secondary/entry/starboard)
@@ -17458,9 +17491,6 @@
 	pixel_x = 29;
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
@@ -17571,8 +17601,7 @@
 	department = "Bar";
 	name = "Bar RC";
 	pixel_y = 32;
-	dir = 1;
-	
+	dir = 1
 	},
 /obj/machinery/vending/boozeomat,
 /turf/floor/lino,
@@ -17634,6 +17663,9 @@
 	pixel_y = 10
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/floor/lino,
 /area/exodus/chapel/office)
 "aLb" = (
@@ -17972,23 +18004,6 @@
 	},
 /turf/floor/plating,
 /area/exodus/maintenance/research_port)
-"aLO" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/status_display,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/blast/regular/open{
-	dir = 2;
-	id_tag = "bridge blast";
-	name = "Bridge Blast Doors"
-	},
-/turf/floor/plating,
-/area/exodus/bridge)
 "aLP" = (
 /obj/machinery/door/airlock/external/bolted{
 	id_tag = "nuke_shuttle_dock_outer";
@@ -18174,6 +18189,10 @@
 	},
 /obj/structure/bed/chair/comfy/brown{
 	dir = 8
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = 22
 	},
 /turf/floor/carpet,
 /area/exodus/crew_quarters/bar)
@@ -18554,6 +18573,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/floor/carpet,
 /area/exodus/crew_quarters/bar)
 "aNe" = (
@@ -18629,6 +18651,9 @@
 	pixel_y = -26
 	},
 /obj/machinery/shield_diffuser,
+/obj/structure/sign/warning/airlock{
+	pixel_y = 32
+	},
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/hallway/secondary/entry/aft)
 "aNm" = (
@@ -18885,6 +18910,9 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
+/obj/structure/sign/warning/secure_area{
+	pixel_y = 32
+	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/central_one)
 "aNM" = (
@@ -19074,6 +19102,9 @@
 	pixel_y = -26
 	},
 /obj/machinery/shield_diffuser,
+/obj/structure/sign/warning/airlock{
+	pixel_y = 32
+	},
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/hallway/secondary/entry/aft)
 "aOe" = (
@@ -19147,9 +19178,6 @@
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -22
-	},
-/obj/machinery/light/small{
-	dir = 8
 	},
 /obj/structure/meat_hook,
 /turf/floor/tiled/freezer,
@@ -19429,13 +19457,6 @@
 	pixel_x = -1;
 	pixel_y = 1
 	},
-/obj/item/radio/intercom{
-	dir = 8;
-	pixel_x = 22
-	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/recharger,
 /obj/machinery/computer/modular/telescreen/preset/generic{
 	dir = 8
@@ -19713,10 +19734,6 @@
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/port)
-"aPr" = (
-/obj/machinery/status_display,
-/turf/wall/prepainted,
-/area/exodus/hallway/primary/central_two)
 "aPs" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -21351,10 +21368,6 @@
 	},
 /turf/floor/plating,
 /area/exodus/hallway/primary/port)
-"aTa" = (
-/obj/machinery/smartfridge,
-/turf/wall/prepainted,
-/area/exodus/crew_quarters/kitchen)
 "aTb" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -21579,11 +21592,11 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/secondary/entry/starboard)
 "aTw" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/structure/sign/warning/airlock,
-/obj/machinery/door/firedoor,
-/turf/floor/plating,
-/area/exodus/hallway/secondary/entry/aft)
+/obj/structure/sign/warning/biohazard{
+	pixel_y = -32
+	},
+/turf/space,
+/area/space)
 "aTx" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
@@ -21831,10 +21844,6 @@
 /turf/wall/prepainted,
 /area/exodus/storage/art)
 "aUf" = (
-/obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = -22
-	},
 /obj/item/stool/bar/padded,
 /obj/machinery/computer/modular/telescreen/preset/generic{
 	dir = 4
@@ -21863,15 +21872,6 @@
 	},
 /turf/floor/plating,
 /area/exodus/maintenance/locker)
-"aUj" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lime{
-	dir = 6
-	},
-/turf/floor/tiled/steel_grid,
-/area/exodus/hallway/primary/central_two)
 "aUk" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -22119,9 +22119,6 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hydroponics/garden)
 "aUP" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
@@ -22967,9 +22964,6 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/camera/network/civilian_west{
 	c_tag = "Locker Room East";
 	dir = 8
@@ -23740,8 +23734,7 @@
 /obj/machinery/network/requests_console{
 	department = "Locker Room";
 	pixel_x = -32;
-	dir = 8;
-	
+	dir = 8
 	},
 /turf/floor/tiled/monotile,
 /area/exodus/crew_quarters/locker)
@@ -23857,9 +23850,17 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/bridge)
 "aYT" = (
-/obj/machinery/status_display,
-/turf/wall/prepainted,
-/area/exodus/hallway/primary/starboard)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/floor/tiled/steel_grid,
+/area/exodus/hallway/primary/central_two)
 "aYU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -23932,8 +23933,7 @@
 	department = "Bridge";
 	name = "Bridge RC";
 	pixel_y = -32;
-	dir = 2;
-	
+	dir = 2
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -24656,14 +24656,14 @@
 	},
 /turf/floor/plating,
 /area/exodus/maintenance/substation/medical)
-"baz" = (
-/obj/structure/sign/warning/high_voltage,
-/turf/wall/prepainted,
-/area/exodus/maintenance/substation/civilian_west)
 "baA" = (
-/obj/structure/sign/warning/high_voltage,
-/turf/wall/prepainted,
-/area/exodus/maintenance/substation/medical)
+/obj/random/obstruction,
+/obj/structure/sign/warning/secure_area{
+	pixel_x = -32;
+	dir = 4
+	},
+/turf/floor/plating,
+/area/exodus/maintenance/engineering)
 "baB" = (
 /obj/structure/closet/toolcloset,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -24688,15 +24688,16 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/central_one)
 "baE" = (
-/obj/structure/sign/warning/secure_area{
-	pixel_x = -32
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
 	id_tag = "bridge blast";
 	name = "Bridge Blast Doors"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/sign/warning/secure_area{
+	pixel_x = -32;
+	dir = 4
+	},
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/bridge)
 "baF" = (
@@ -25192,9 +25193,6 @@
 "bbF" = (
 /obj/structure/table,
 /obj/machinery/faxmachine/mapped,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/status_display{
 	pixel_x = 32;
 	dir = 4
@@ -25612,10 +25610,6 @@
 	},
 /turf/floor/plating,
 /area/exodus/medical/surgery2)
-"bcy" = (
-/obj/structure/sign/warning/docking_area,
-/turf/wall/r_wall/prepainted,
-/area/exodus/hallway/secondary/entry/aft)
 "bcz" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/blue{
@@ -26011,6 +26005,9 @@
 /area/exodus/security/vacantoffice)
 "bdn" = (
 /obj/machinery/photocopier,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/floor/tiled/dark,
 /area/exodus/security/vacantoffice)
 "bdo" = (
@@ -26497,10 +26494,11 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hydroponics/garden)
 "bev" = (
+/obj/machinery/light,
 /obj/machinery/firealarm{
+	dir = 1;
 	pixel_y = -24
 	},
-/obj/machinery/light,
 /turf/floor/lino,
 /area/exodus/security/vacantoffice)
 "bew" = (
@@ -26843,8 +26841,7 @@
 	department = "Kitchen";
 	name = "Kitchen RC";
 	pixel_y = -32;
-	dir = 2;
-	
+	dir = 2
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -26917,9 +26914,6 @@
 "bfp" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /turf/floor/wood/walnut,
 /area/exodus/bridge/meeting_room)
@@ -27146,9 +27140,9 @@
 /turf/floor/tiled/freezer,
 /area/exodus/crew_quarters/locker/locker_toilet)
 "bfQ" = (
-/obj/structure/sign/double/barsign,
-/turf/wall/prepainted,
-/area/exodus/hallway/primary/starboard)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/floor/tiled/white,
+/area/exodus/research/xenobiology)
 "bfR" = (
 /obj/machinery/status_display{
 	pixel_x = -32;
@@ -27302,8 +27296,7 @@
 /obj/machinery/network/requests_console{
 	department = "Cargo Bay";
 	pixel_y = 32;
-	dir = 1;
-	
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/white{
 	dir = 4
@@ -27322,9 +27315,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/light/small/red{
-	dir = 8
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
@@ -27341,9 +27331,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/status_display{
 	pixel_x = -32;
-	dir = 8
-	},
-/obj/machinery/light{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/blue{
@@ -28047,10 +28034,6 @@
 /obj/effect/floor_decal/corner/blue,
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/office)
-"bhM" = (
-/obj/structure/sign/warning/nosmoking_1,
-/turf/wall/prepainted,
-/area/exodus/hallway/primary/starboard)
 "bhN" = (
 /obj/machinery/camera/network/civilian_west{
 	c_tag = "Warehouse"
@@ -28122,9 +28105,6 @@
 /turf/floor/carpet,
 /area/exodus/crew_quarters/captain)
 "bhV" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/papershredder,
 /turf/floor/wood/walnut,
@@ -28148,6 +28128,7 @@
 /obj/item/cell{
 	maxcharge = 2000
 	},
+/obj/machinery/light/small/red,
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/storage)
 "bhY" = (
@@ -28313,6 +28294,9 @@
 /obj/structure/table/woodentable,
 /obj/structure/cable/green{
 	icon_state = "4-8"
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/floor/wood/walnut,
 /area/exodus/bridge/meeting_room)
@@ -28585,9 +28569,6 @@
 	dir = 1;
 	id_tag = "garbage"
 	},
-/obj/structure/sign/warning/vacuum{
-	pixel_x = -32
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -28613,10 +28594,6 @@
 	},
 /turf/floor/tiled/freezer,
 /area/exodus/crew_quarters/locker/locker_toilet)
-"biW" = (
-/obj/structure/sign/department/examroom,
-/turf/wall/prepainted,
-/area/exodus/medical/reception)
 "biX" = (
 /obj/machinery/network/relay,
 /turf/floor/tiled/dark/monotile,
@@ -28670,8 +28647,7 @@
 /obj/machinery/network/requests_console{
 	department = "AI";
 	pixel_y = 32;
-	dir = 1;
-	
+	dir = 1
 	},
 /obj/structure/cable/cyan{
 	icon_state = "0-2"
@@ -29085,6 +29061,9 @@
 /area/exodus/bridge/meeting_room)
 "bjM" = (
 /obj/structure/reagent_dispensers/water_cooler,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/floor/wood/walnut,
 /area/exodus/bridge/meeting_room)
 "bjN" = (
@@ -29548,7 +29527,6 @@
 /turf/floor/tiled/white,
 /area/exodus/medical/exam_room)
 "bkG" = (
-/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -29641,6 +29619,9 @@
 /obj/machinery/camera/network/command{
 	c_tag = "Bridge - Captain's Office";
 	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/floor/wood/walnut,
 /area/exodus/crew_quarters/captain)
@@ -29844,7 +29825,6 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/structure/sign/department/mail_delivery,
 /turf/wall/prepainted,
 /area/exodus/quartermaster/office)
 "bln" = (
@@ -29855,9 +29835,6 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/starboard)
 "blo" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
@@ -29893,8 +29870,7 @@
 	department = "Bridge";
 	name = "Bridge RC";
 	pixel_y = -32;
-	dir = 2;
-	
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -29930,6 +29906,10 @@
 /area/exodus/maintenance/locker)
 "blw" = (
 /obj/machinery/space_heater,
+/obj/structure/sign/directions/pods{
+	dir = 1;
+	pixel_y = 32
+	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/maintenance/atmos_control)
 "blx" = (
@@ -29962,6 +29942,10 @@
 "blB" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 4
+	},
+/obj/structure/sign/department/mail_delivery{
+	dir = 4;
+	pixel_x = -32
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/office)
@@ -30064,10 +30048,6 @@
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/central_one)
-"blM" = (
-/obj/structure/sign/warning/docking_area,
-/turf/wall/r_wall/prepainted,
-/area/exodus/storage/emergency)
 "blN" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/command{
@@ -30093,11 +30073,12 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/storage)
 "blQ" = (
-/obj/structure/sign/department/star_of_life{
-	name = "Medbay"
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/wall/prepainted,
-/area/exodus/hallway/primary/starboard)
+/turf/floor/tiled/monotile,
+/area/exodus/crew_quarters/locker)
 "blR" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-4"
@@ -30202,6 +30183,10 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
+/obj/structure/sign/department/star_of_life{
+	name = "Medbay";
+	pixel_y = 32
+	},
 /turf/floor/tiled/white,
 /area/exodus/medical/reception)
 "bmc" = (
@@ -30234,6 +30219,9 @@
 /obj/item/stool/padded,
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
+	},
+/obj/structure/sign/warning/nosmoking_1{
+	pixel_y = 32
 	},
 /turf/floor/tiled/white,
 /area/exodus/medical/reception)
@@ -30419,6 +30407,9 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
+/obj/structure/sign/warning/nosmoking_1{
+	pixel_y = 32
+	},
 /turf/floor/tiled/white,
 /area/exodus/medical/reception)
 "bmx" = (
@@ -30484,9 +30475,6 @@
 /turf/floor/tiled/white,
 /area/exodus/medical/exam_room)
 "bmD" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/disposal,
 /obj/machinery/firealarm{
 	dir = 4;
@@ -30595,8 +30583,7 @@
 	department = "Captain's Desk";
 	name = "Captain RC";
 	pixel_x = -32;
-	dir = 8;
-	
+	dir = 8
 	},
 /obj/structure/filing_cabinet,
 /turf/floor/wood/walnut,
@@ -30686,7 +30673,6 @@
 /turf/floor/plating,
 /area/exodus/maintenance/research_port)
 "bmY" = (
-/obj/structure/sign/department/chemistry,
 /turf/wall/r_wall/prepainted,
 /area/exodus/medical/chemistry)
 "bmZ" = (
@@ -30769,10 +30755,6 @@
 	department = "Robotics";
 	name = "Robotics RC";
 	pixel_y = 32;
-	dir = 1;
-	
-	},
-/obj/machinery/light{
 	dir = 1
 	},
 /obj/item/chems/glass/beaker/large,
@@ -30796,9 +30778,11 @@
 /turf/wall/prepainted,
 /area/exodus/medical/reception)
 "bnj" = (
-/obj/machinery/status_display,
-/turf/wall/r_wall/prepainted,
-/area/exodus/turret_protected/ai)
+/obj/structure/sign/warning/secure_area{
+	pixel_y = 32
+	},
+/turf/space,
+/area/space)
 "bnk" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -30822,6 +30806,7 @@
 /obj/item/radio/intercom{
 	pixel_y = 20
 	},
+/obj/structure/sign/department/chemistry,
 /turf/floor/tiled/white,
 /area/exodus/medical/reception)
 "bnm" = (
@@ -30912,6 +30897,13 @@
 	},
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
+	},
+/obj/structure/sign/warning/vacuum{
+	dir = 8;
+	pixel_x = 32
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/secondary/entry/aft)
@@ -31047,6 +31039,9 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/maintenance/substation/command)
 "bnF" = (
@@ -31120,9 +31115,12 @@
 /turf/floor/tiled/white,
 /area/exodus/medical/chemistry)
 "bnP" = (
-/obj/structure/sign/warning/docking_area,
-/turf/wall/r_wall/prepainted,
-/area/exodus/maintenance/locker)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/floor/tiled/freezer,
+/area/exodus/medical/patient_wing/washroom)
 "bnQ" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -31246,6 +31244,10 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
 	},
+/obj/structure/sign/department/examroom{
+	pixel_x = 32;
+	dir = 8
+	},
 /turf/floor/tiled/white,
 /area/exodus/medical/reception)
 "bog" = (
@@ -31345,7 +31347,9 @@
 /turf/floor/wood/walnut,
 /area/exodus/crew_quarters/captain)
 "bov" = (
-/obj/structure/morgue,
+/obj/structure/morgue{
+	dir = 4
+	},
 /turf/floor/tiled/dark,
 /area/exodus/medical/morgue)
 "bow" = (
@@ -31693,18 +31697,23 @@
 /obj/machinery/network/requests_console{
 	department = "Cargo Bay";
 	pixel_y = 32;
-	dir = 1;
-	
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/storage)
 "bpf" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/structure/sign/warning/airlock,
-/obj/machinery/door/firedoor,
-/turf/floor/plating,
-/area/exodus/quartermaster/storage)
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/medical_wall/pills{
+	pixel_y = 32
+	},
+/obj/item/chems/syringe/stabilizer,
+/obj/item/chems/syringe/antibiotic,
+/obj/item/chems/syringe/antibiotic,
+/turf/floor/tiled/white,
+/area/exodus/medical/sleeper)
 "bpg" = (
 /obj/item/stack/package_wrap,
 /obj/item/hand_labeler,
@@ -31870,6 +31879,10 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
+/obj/structure/sign/warning/high_voltage{
+	dir = 8;
+	pixel_x = 32
+	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/central_one)
 "bpB" = (
@@ -31964,9 +31977,6 @@
 /turf/floor/tiled/white,
 /area/exodus/research/lab)
 "bpI" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	icon_state = "2-8"
@@ -31998,9 +32008,14 @@
 /turf/floor/plating,
 /area/exodus/storage/emergency)
 "bpK" = (
-/obj/machinery/ai_status_display,
-/turf/wall/r_wall/prepainted,
-/area/exodus/turret_protected/ai)
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/floor/tiled/steel_grid,
+/area/exodus/hallway/primary/central_two)
 "bpL" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
@@ -32008,9 +32023,6 @@
 /turf/floor/plating,
 /area/exodus/storage/emergency)
 "bpM" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/camera/network/command{
 	c_tag = "AI Upload - West";
 	dir = 4
@@ -32239,6 +32251,9 @@
 /area/exodus/quartermaster/storage)
 "bqi" = (
 /obj/structure/bed/padded,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/floor/tiled/white,
 /area/exodus/medical/exam_room)
 "bqj" = (
@@ -32504,6 +32519,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/floor/tiled/white,
 /area/exodus/research)
 "bqK" = (
@@ -32599,9 +32617,6 @@
 /obj/item/stock_parts/scanning_module,
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 29;
 	dir = 8
@@ -32641,7 +32656,8 @@
 /area/exodus/maintenance/research_shuttle)
 "bqY" = (
 /obj/structure/sign/warning/docking_area{
-	pixel_y = -32
+	pixel_y = -32;
+	dir = 1
 	},
 /turf/space,
 /area/space)
@@ -32720,9 +32736,6 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/office)
 "brj" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/status_display{
 	pixel_x = 32;
 	dir = 4
@@ -32997,6 +33010,10 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
+/obj/structure/sign/warning/high_voltage{
+	dir = 4;
+	pixel_x = -32
+	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/maintenance/substation/command)
 "brJ" = (
@@ -33062,7 +33079,6 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/obj/item/radio/intercom,
 /turf/floor/tiled/steel_grid,
 /area/exodus/medical/reception)
 "brQ" = (
@@ -33301,9 +33317,6 @@
 /area/exodus/medical/genetics)
 "bss" = (
 /obj/structure/closet/firecloset,
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -33399,6 +33412,9 @@
 /obj/machinery/door/window/eastright{
 	dir = 8;
 	name = "Sublevel Access"
+	},
+/obj/machinery/ai_status_display{
+	pixel_y = 32
 	},
 /turf/floor/bluegrid,
 /area/exodus/turret_protected/ai_upload)
@@ -33629,9 +33645,6 @@
 /turf/floor/plating,
 /area/exodus/maintenance/research_shuttle)
 "btf" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -33841,10 +33854,6 @@
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/medical/reception)
-"btz" = (
-/obj/machinery/status_display/supply_display,
-/turf/wall/prepainted,
-/area/exodus/quartermaster/office)
 "btA" = (
 /obj/item/radio/intercom{
 	dir = 1;
@@ -33902,9 +33911,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/secondary/entry/fore)
@@ -34339,6 +34345,9 @@
 	dir = 1;
 	current_health = 1e+006
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/floor/tiled/white,
 /area/exodus/research/xenobiology)
 "buA" = (
@@ -34547,6 +34556,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
+	},
+/obj/machinery/status_display/supply_display{
+	pixel_y = 32
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/office)
@@ -34962,10 +34974,11 @@
 	pixel_x = -8;
 	pixel_y = 4
 	},
-/obj/machinery/light{
+/obj/item/toolbox/mechanical,
+/obj/machinery/status_display{
+	pixel_x = 32;
 	dir = 4
 	},
-/obj/item/toolbox/mechanical,
 /turf/floor/tiled/steel_grid,
 /area/exodus/research/robotics)
 "bvD" = (
@@ -35043,11 +35056,9 @@
 /turf/wall/titanium,
 /area/ship/exodus_pod_research)
 "bvP" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/status_display,
-/obj/machinery/door/firedoor,
-/turf/floor/plating,
-/area/exodus/medical/virology)
+/obj/machinery/light,
+/turf/floor/tiled/steel_grid,
+/area/exodus/security/range)
 "bvQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -35203,6 +35214,9 @@
 /obj/effect/floor_decal/corner/brown{
 	dir = 1
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/office)
 "bwi" = (
@@ -35249,6 +35263,9 @@
 	dir = 4
 	},
 /obj/item/aiModule/reset,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/floor/bluegrid,
 /area/exodus/turret_protected/ai_upload)
 "bwo" = (
@@ -35313,9 +35330,11 @@
 /turf/floor/plating,
 /area/exodus/maintenance/substation/medical)
 "bwv" = (
-/obj/machinery/status_display,
-/turf/wall/r_wall/prepainted,
-/area/exodus/research/robotics)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/floor/tiled/white,
+/area/exodus/research/xenobiology)
 "bww" = (
 /turf/wall/r_wall/prepainted,
 /area/exodus/research)
@@ -35326,6 +35345,9 @@
 	dir = 8
 	},
 /obj/item/aiModule/protectStation,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/floor/bluegrid,
 /area/exodus/turret_protected/ai_upload)
 "bwy" = (
@@ -35387,10 +35409,6 @@
 	},
 /turf/floor/carpet,
 /area/exodus/crew_quarters/captain)
-"bwD" = (
-/obj/machinery/smartfridge/secure/medbay,
-/turf/wall/prepainted,
-/area/exodus/medical/chemistry)
 "bwE" = (
 /turf/wall/prepainted,
 /area/exodus/engineering/drone_fabrication)
@@ -35479,12 +35497,13 @@
 /turf/floor/plating,
 /area/exodus/maintenance/atmos_control)
 "bwP" = (
-/obj/structure/sign/warning/secure_area{
-	pixel_x = -32
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
+	},
+/obj/structure/sign/warning/secure_area{
+	pixel_x = -32;
+	dir = 4
 	},
 /turf/floor/plating,
 /area/exodus/maintenance/atmos_control)
@@ -35616,10 +35635,6 @@
 /turf/floor/tiled/white,
 /area/exodus/medical/chemistry)
 "bxb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
@@ -35630,6 +35645,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/floor/tiled/white,
 /area/exodus/medical/chemistry)
 "bxc" = (
@@ -35938,8 +35954,7 @@
 	department = "Science";
 	name = "Science Requests Console";
 	pixel_y = 32;
-	dir = 1;
-	
+	dir = 1
 	},
 /obj/structure/table{
 	name = "plastic table frame"
@@ -36249,6 +36264,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/floor/tiled/white,
 /area/exodus/medical/chemistry)
 "byv" = (
@@ -36471,6 +36490,10 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
+/obj/structure/sign/warning/high_voltage{
+	dir = 8;
+	pixel_x = 32
+	},
 /turf/floor/tiled/white,
 /area/exodus/medical/medbay2)
 "byT" = (
@@ -36734,8 +36757,7 @@
 /obj/machinery/network/requests_console{
 	department = "Cargo Bay";
 	pixel_x = -32;
-	dir = 8;
-	
+	dir = 8
 	},
 /obj/machinery/camera/network/civilian_west{
 	c_tag = "Cargo Office";
@@ -36875,6 +36897,9 @@
 	id_tag = "cargo_bay_door";
 	name = "Cargo Docking Hatch"
 	},
+/obj/structure/sign/warning/airlock{
+	pixel_y = 32
+	},
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/quartermaster/storage)
 "bzL" = (
@@ -36897,6 +36922,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/cable/cyan{
 	icon_state = "0-2"
+	},
+/obj/structure/sign/warning/lethal_turrets{
+	pixel_x = 32
 	},
 /turf/floor/tiled/dark,
 /area/exodus/turret_protected/ai_server_room)
@@ -36966,6 +36994,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/cable/cyan{
 	icon_state = "0-2"
+	},
+/obj/structure/sign/warning/lethal_turrets{
+	pixel_x = -32
 	},
 /turf/floor/tiled/dark,
 /area/exodus/turret_protected/ai_cyborg_station)
@@ -37418,6 +37449,10 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
+/obj/structure/sign/warning/high_voltage{
+	dir = 4;
+	pixel_x = -32
+	},
 /turf/floor/plating,
 /area/exodus/maintenance/research_port)
 "bAH" = (
@@ -37488,6 +37523,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/machinery/light,
 /turf/floor/tiled/white,
 /area/exodus/research/robotics)
 "bAP" = (
@@ -37971,7 +38007,8 @@
 	},
 /obj/item/stool,
 /obj/structure/sign/warning/secure_area{
-	pixel_x = -32
+	pixel_x = -32;
+	dir = 4
 	},
 /turf/floor/tiled/monotile,
 /area/exodus/teleporter)
@@ -38149,9 +38186,6 @@
 "bCg" = (
 /obj/machinery/ai_status_display{
 	pixel_x = 32
-	},
-/obj/machinery/light{
-	dir = 4
 	},
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -38438,9 +38472,6 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/office)
 "bCO" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -38525,9 +38556,6 @@
 "bCW" = (
 /obj/abstract/landmark/start{
 	name = "Cyborg"
-	},
-/obj/machinery/light/small{
-	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -38664,15 +38692,16 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/central_two)
 "bDk" = (
-/obj/structure/sign/warning/secure_area{
-	pixel_x = -32
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
+	},
+/obj/structure/sign/warning/secure_area{
+	pixel_x = -32;
+	dir = 4
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/central_two)
@@ -38802,13 +38831,6 @@
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/storage/primary)
-"bDv" = (
-/obj/structure/closet/secure_closet/medical_wall/pills,
-/obj/item/chems/syringe/antibiotic,
-/obj/item/chems/syringe/antibiotic,
-/obj/item/chems/syringe/stabilizer,
-/turf/wall/prepainted,
-/area/exodus/medical/sleeper)
 "bDw" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -38826,10 +38848,6 @@
 	},
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/hallway/primary/port)
-"bDy" = (
-/obj/machinery/status_display,
-/turf/wall/prepainted,
-/area/exodus/medical/medbay)
 "bDz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -38907,6 +38925,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/sign/warning/secure_area{
+	pixel_x = 32;
 	dir = 8
 	},
 /turf/floor/plating,
@@ -39032,7 +39054,6 @@
 /turf/floor/bluegrid,
 /area/exodus/research/server)
 "bDU" = (
-/obj/structure/sign/warning/secure_area,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -39331,8 +39352,7 @@
 	department = "Head of Personnel's Desk";
 	name = "Head of Personnel RC";
 	pixel_y = -32;
-	dir = 2;
-	
+	dir = 2
 	},
 /obj/machinery/camera/network/command{
 	c_tag = "Bridge - HoP's Office";
@@ -39587,6 +39607,10 @@
 	id_tag = "cargo_bay_door";
 	name = "Cargo Docking Hatch"
 	},
+/obj/structure/sign/warning/airlock{
+	pixel_y = -32;
+	dir = 1
+	},
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/quartermaster/storage)
 "bFc" = (
@@ -39712,6 +39736,9 @@
 /obj/machinery/computer/modular/preset/security{
 	dir = 1
 	},
+/obj/machinery/ai_status_display{
+	pixel_y = -32
+	},
 /turf/floor/bluegrid,
 /area/exodus/turret_protected/ai)
 "bFp" = (
@@ -39777,10 +39804,6 @@
 	},
 /turf/floor/tiled/white,
 /area/exodus/research)
-"bFv" = (
-/obj/structure/sign/warning/lethal_turrets,
-/turf/wall/r_wall/prepainted,
-/area/exodus/turret_protected/ai_server_room)
 "bFw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40118,6 +40141,10 @@
 /obj/machinery/computer/modular/preset/engineering{
 	dir = 1
 	},
+/obj/machinery/status_display{
+	pixel_y = -32;
+	dir = 1
+	},
 /turf/floor/bluegrid,
 /area/exodus/turret_protected/ai)
 "bGg" = (
@@ -40155,10 +40182,6 @@
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/port)
-"bGi" = (
-/obj/machinery/status_display/supply_display,
-/turf/wall/prepainted,
-/area/exodus/quartermaster/qm)
 "bGj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40292,6 +40315,10 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/lime,
+/obj/machinery/status_display{
+	pixel_x = 32;
+	dir = 4
+	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/central_three)
 "bGv" = (
@@ -40334,14 +40361,20 @@
 /turf/floor/tiled/white,
 /area/exodus/medical/sleeper)
 "bGB" = (
-/obj/machinery/status_display,
-/turf/wall/prepainted,
-/area/exodus/hallway/primary/central_three)
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/firedoor,
+/obj/structure/sign/warning/docking_area{
+	dir = 8;
+	pixel_x = 32
+	},
+/turf/floor/plating,
+/area/exodus/hallway/secondary/entry/aft)
 "bGC" = (
 /obj/machinery/camera/network/command{
 	c_tag = "AI - Messaging Server";
 	dir = 1
 	},
+/obj/machinery/light/small,
 /turf/floor/bluegrid,
 /area/exodus/turret_protected/ai_server_room)
 "bGD" = (
@@ -40360,6 +40393,7 @@
 	c_tag = "AI - Cyborg Station";
 	dir = 1
 	},
+/obj/machinery/light/small,
 /turf/floor/bluegrid,
 /area/exodus/turret_protected/ai_cyborg_station)
 "bGF" = (
@@ -40437,8 +40471,7 @@
 	department = "Medbay";
 	name = "Medbay RC";
 	pixel_y = 32;
-	dir = 1;
-	
+	dir = 1
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -40954,12 +40987,6 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
 "bHE" = (
-/obj/machinery/network/requests_console{
-	department = "Cargo Bay";
-	pixel_y = 32;
-	dir = 1;
-	
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/qm)
@@ -41593,9 +41620,12 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/research/storage)
 "bIQ" = (
-/obj/structure/sign/warning/lethal_turrets,
+/obj/structure/sign/warning/docking_area{
+	dir = 4;
+	pixel_x = -32
+	},
 /turf/wall/r_wall/prepainted,
-/area/exodus/turret_protected/ai_cyborg_station)
+/area/exodus/hallway/secondary/entry/aft)
 "bIR" = (
 /obj/structure/rack{
 	dir = 8
@@ -41648,6 +41678,10 @@
 /obj/item/wirecutters,
 /obj/structure/table/steel,
 /obj/item/crowbar/brace_jack,
+/obj/structure/sign/warning/secure_area{
+	pixel_x = -32;
+	dir = 4
+	},
 /turf/floor/plating,
 /area/exodus/storage/tech)
 "bIX" = (
@@ -41692,8 +41726,7 @@
 /obj/machinery/network/requests_console{
 	department = "Cargo Bay";
 	pixel_x = -32;
-	dir = 8;
-	
+	dir = 8
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
@@ -42101,6 +42134,9 @@
 "bJJ" = (
 /obj/structure/table,
 /obj/item/defibrillator/loaded,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/floor/tiled/white,
 /area/exodus/medical/sleeper)
 "bJK" = (
@@ -43796,6 +43832,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
 	},
+/obj/structure/sign/warning/docking_area{
+	pixel_y = 32
+	},
 /turf/floor,
 /area/exodus/quartermaster/miningdock)
 "bNh" = (
@@ -43875,6 +43914,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/sign/warning/biohazard{
+	pixel_y = -32
 	},
 /turf/floor/plating,
 /area/exodus/research/xenobiology)
@@ -44005,6 +44047,11 @@
 /obj/structure/table,
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/network/requests_console{
+	department = "Cargo Bay";
+	pixel_y = -32;
+	dir = 1
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/qm)
@@ -44329,6 +44376,10 @@
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
+	},
+/obj/structure/sign/warning/high_voltage{
+	dir = 1;
+	pixel_y = -32
 	},
 /turf/floor/plating,
 /area/exodus/maintenance/research_starboard)
@@ -45008,8 +45059,7 @@
 	department = "Chief Medical Officer's Desk";
 	name = "Chief Medical Officer RC";
 	pixel_x = -32;
-	dir = 8;
-	
+	dir = 8
 	},
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medbay - CMO's Office";
@@ -45227,8 +45277,7 @@
 	department = "Science";
 	name = "Science Requests Console";
 	pixel_x = 32;
-	dir = 4;
-	
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/floor/tiled/white,
@@ -45419,10 +45468,6 @@
 /obj/item/scanner/plant,
 /turf/floor/plating,
 /area/exodus/storage/tech)
-"bQC" = (
-/obj/structure/sign/warning/high_voltage,
-/turf/wall/r_wall/prepainted,
-/area/exodus/storage/tech)
 "bQD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -45534,8 +45579,7 @@
 /obj/machinery/network/requests_console{
 	department = "Janitorial";
 	pixel_y = -32;
-	dir = 2;
-	
+	dir = 2
 	},
 /obj/item/chems/spray/cleaner,
 /obj/structure/table/steel,
@@ -45578,6 +45622,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
+	},
+/obj/structure/sign/warning/high_voltage{
+	dir = 4;
+	pixel_x = -32
 	},
 /turf/floor/plating,
 /area/exodus/maintenance/engineering)
@@ -45631,9 +45679,6 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/janitor)
 "bQY" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/bed/roller,
 /obj/machinery/alarm{
 	dir = 4;
@@ -45777,9 +45822,6 @@
 /turf/floor/tiled/white,
 /area/exodus/medical/patient_a)
 "bRi" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
@@ -45831,9 +45873,6 @@
 /turf/floor/tiled/white,
 /area/exodus/medical/patient_b)
 "bRm" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
@@ -46338,6 +46377,10 @@
 /obj/item/aicard,
 /obj/item/aiModule/reset,
 /obj/structure/table/steel,
+/obj/structure/sign/warning/high_voltage{
+	dir = 4;
+	pixel_x = -32
+	},
 /turf/floor/plating,
 /area/exodus/storage/tech)
 "bSm" = (
@@ -46534,8 +46577,7 @@
 /obj/machinery/network/requests_console{
 	department = "Tech storage";
 	pixel_x = 32;
-	dir = 4;
-	
+	dir = 4
 	},
 /turf/floor/plating,
 /area/exodus/storage/tech)
@@ -46685,6 +46727,9 @@
 "bSY" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
+/obj/structure/sign/warning/biohazard{
+	pixel_y = -32
+	},
 /turf/floor/plating,
 /area/exodus/research/xenobiology/xenoflora)
 "bSZ" = (
@@ -46840,10 +46885,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/aft)
-"bTr" = (
-/obj/structure/sign/warning/secure_area,
-/turf/wall/r_wall/prepainted,
-/area/exodus/storage/tech)
 "bTs" = (
 /obj/machinery/door/blast/shutters/open{
 	dir = 2;
@@ -46973,6 +47014,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/pink/three_quarters,
+/obj/machinery/light,
 /turf/floor/tiled/white,
 /area/exodus/medical/patient_a)
 "bTI" = (
@@ -47015,6 +47057,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/pink/three_quarters,
+/obj/machinery/light,
 /turf/floor/tiled/white,
 /area/exodus/medical/patient_b)
 "bTM" = (
@@ -47219,11 +47262,11 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/crew_quarters/heads/chief)
 "bUb" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/door/firedoor,
-/obj/structure/sign/warning/docking_area,
-/turf/floor/plating,
-/area/exodus/quartermaster/miningdock)
+/obj/structure/sign/plaque/golden{
+	pixel_y = 32
+	},
+/turf/floor/tiled/dark,
+/area/exodus/crew_quarters/heads/hos)
 "bUc" = (
 /obj/machinery/atmospherics/binary/passive_gate{
 	dir = 8
@@ -48621,8 +48664,7 @@
 	department = "Chief Engineer's Desk";
 	name = "Chief Engineer RC";
 	pixel_y = 32;
-	dir = 1;
-	
+	dir = 1
 	},
 /obj/machinery/newscaster{
 	pixel_x = -28;
@@ -48791,10 +48833,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/floor/tiled/steel_grid,
 /area/exodus/medical/sleeper)
-"bXx" = (
-/obj/structure/sign/warning/biohazard,
-/turf/wall/r_wall/prepainted,
-/area/exodus/research/xenobiology)
 "bXy" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1
@@ -48872,6 +48910,10 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/structure/sign/department/greencross{
+	pixel_y = -32;
+	dir = 1
+	},
 /turf/floor/tiled/white,
 /area/exodus/medical/medbay4)
 "bXF" = (
@@ -48911,6 +48953,10 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/sign/warning/radioactive{
+	pixel_y = -32;
+	dir = 1
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/engineering)
@@ -49076,9 +49122,11 @@
 /turf/wall/r_wall/prepainted,
 /area/exodus/maintenance/substation/research)
 "bXZ" = (
-/obj/structure/sign/warning/high_voltage,
-/turf/wall/r_wall/prepainted,
-/area/exodus/maintenance/substation/research)
+/obj/structure/sign/warning/docking_area{
+	pixel_y = 32
+	},
+/turf/floor/airless,
+/area/space)
 "bYa" = (
 /obj/abstract/landmark/start{
 	name = "Scientist"
@@ -49196,9 +49244,6 @@
 "bYk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4
 	},
 /obj/item/radio/intercom{
 	pixel_y = 20
@@ -49462,6 +49507,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/sign/warning/radioactive{
+	pixel_y = -32;
+	dir = 1
+	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/engineering)
 "bYG" = (
@@ -49647,9 +49696,6 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/crew_quarters/sleep/engi_wash)
 "bZc" = (
-/obj/structure/sign/directions/pods{
-	dir = 1
-	},
 /turf/wall/r_wall/prepainted,
 /area/exodus/engineering/engine_eva)
 "bZd" = (
@@ -49768,10 +49814,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/floor/tiled/white,
-/area/exodus/medical/medbay4)
-"bZq" = (
-/obj/structure/sign/department/greencross,
-/turf/wall/prepainted,
 /area/exodus/medical/medbay4)
 "bZr" = (
 /obj/structure/rack{
@@ -49965,6 +50007,10 @@
 	dir = 8
 	},
 /obj/structure/closet/wardrobe/science_white,
+/obj/structure/sign/warning/high_voltage{
+	dir = 1;
+	pixel_y = -32
+	},
 /turf/floor/tiled/white,
 /area/exodus/research/misc_lab)
 "bZN" = (
@@ -50377,6 +50423,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/floor/tiled/white,
 /area/exodus/medical/medbay4)
 "caC" = (
@@ -50459,6 +50508,9 @@
 /obj/effect/floor_decal/corner/pink{
 	dir = 5
 	},
+/obj/structure/sign/department/greencross{
+	pixel_y = 32
+	},
 /turf/floor/tiled/white,
 /area/exodus/medical/ward)
 "caM" = (
@@ -50487,9 +50539,6 @@
 /turf/floor/tiled/white,
 /area/exodus/medical/patient_wing)
 "caO" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 29;
 	dir = 8
@@ -50715,6 +50764,9 @@
 /obj/effect/floor_decal/corner/purple{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/floor/tiled/white,
 /area/exodus/research/xenobiology)
 "cbp" = (
@@ -50722,11 +50774,13 @@
 	department = "Science";
 	name = "Science Requests Console";
 	pixel_y = 32;
-	dir = 1;
-	
+	dir = 1
 	},
 /obj/machinery/camera/network/research{
 	c_tag = "Xenobiology North"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/floor/tiled/white,
 /area/exodus/research/xenobiology)
@@ -50940,9 +50994,6 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/engineering/engine_monitoring)
 "cbN" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -51003,6 +51054,9 @@
 /area/exodus/engineering/sublevel_access)
 "cbV" = (
 /obj/structure/bed/roller,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/floor/tiled/white,
 /area/exodus/medical/patient_wing)
 "cbW" = (
@@ -51077,9 +51131,14 @@
 /turf/floor/tiled/freezer,
 /area/exodus/medical/patient_wing/washroom)
 "ccd" = (
-/obj/structure/sign/warning/high_voltage,
-/turf/wall/prepainted,
-/area/exodus/maintenance/substation/research)
+/obj/effect/floor_decal/corner/lime{
+	dir = 5
+	},
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
+/turf/floor/tiled/steel_grid,
+/area/exodus/hallway/primary/starboard)
 "cce" = (
 /obj/structure/cable/green{
 	icon_state = "0-4"
@@ -51360,9 +51419,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 29;
 	dir = 8
@@ -51448,7 +51504,6 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/crew_quarters/heads/chief)
 "ccP" = (
-/obj/structure/sign/warning/biohazard,
 /turf/wall/prepainted,
 /area/exodus/medical/virology/access)
 "ccQ" = (
@@ -51462,6 +51517,9 @@
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/engineering/foyer)
@@ -51780,9 +51838,6 @@
 /turf/floor/tiled/white,
 /area/exodus/medical/ward)
 "cdr" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/newscaster{
 	pixel_x = 30;
 	dir = 4
@@ -51919,13 +51974,14 @@
 /turf/floor/fake_grass,
 /area/exodus/hydroponics/garden)
 "cdE" = (
-/obj/structure/sign/warning/secure_area{
-	pixel_x = -32
-	},
 /obj/structure/hygiene/shower{
 	dir = 4;
 	pixel_x = 5;
 	pixel_y = -5
+	},
+/obj/structure/sign/warning/secure_area{
+	pixel_x = -32;
+	dir = 4
 	},
 /turf/floor/tiled/white,
 /area/exodus/research/xenobiology)
@@ -52064,6 +52120,9 @@
 /obj/effect/floor_decal/corner/purple{
 	dir = 10
 	},
+/obj/structure/sign/warning/biohazard{
+	pixel_y = -32
+	},
 /turf/floor/tiled/white,
 /area/exodus/research/xenobiology)
 "cdS" = (
@@ -52081,10 +52140,13 @@
 /obj/effect/floor_decal/corner/purple{
 	dir = 10
 	},
+/obj/structure/sign/warning/secure_area{
+	dir = 1;
+	pixel_y = -32
+	},
 /turf/floor/tiled/white,
 /area/exodus/research/xenobiology)
 "cdW" = (
-/obj/structure/sign/warning/secure_area,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -52260,9 +52322,6 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
 	},
@@ -52358,15 +52417,13 @@
 	tag_exterior_door = "merchant_shuttle_station_exterior";
 	tag_interior_door = "merchant_shuttle_station_interior"
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/machinery/airlock_sensor{
 	id_tag = "merchant_shuttle_station_sensor";
 	pixel_y = -32;
 	dir = 1
 	},
+/obj/machinery/light/small,
 /turf/floor/plating,
 /area/exodus/hallway/secondary/entry/fore)
 "cey" = (
@@ -52378,14 +52435,9 @@
 /turf/floor,
 /area/exodus/maintenance/atmos_control)
 "cez" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 9
-	},
-/turf/floor/tiled/steel_grid,
-/area/exodus/engineering/foyer)
+/obj/machinery/smartfridge/secure/medbay,
+/turf/floor/tiled/white,
+/area/exodus/medical/chemistry)
 "ceA" = (
 /obj/machinery/light{
 	dir = 4
@@ -52483,11 +52535,12 @@
 	pixel_x = 5;
 	pixel_y = -5
 	},
-/obj/structure/sign/warning/secure_area{
-	pixel_x = -32
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
+	},
+/obj/structure/sign/warning/secure_area{
+	pixel_x = -32;
+	dir = 4
 	},
 /turf/floor/tiled/white,
 /area/exodus/medical/virology)
@@ -52560,9 +52613,14 @@
 /turf/floor/tiled/white,
 /area/exodus/medical/ward)
 "ceW" = (
-/obj/structure/sign/warning/biohazard,
-/turf/wall/prepainted,
-/area/exodus/research/xenobiology)
+/obj/effect/floor_decal/corner/lime{
+	dir = 5
+	},
+/obj/structure/sign/double/barsign{
+	pixel_y = 32
+	},
+/turf/floor/tiled/steel_grid,
+/area/exodus/hallway/primary/starboard)
 "ceX" = (
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medbay Mental Health Room";
@@ -52576,6 +52634,9 @@
 "ceY" = (
 /obj/machinery/vending/medical{
 	dir = 8
+	},
+/obj/structure/sign/warning/biohazard{
+	pixel_y = -32
 	},
 /turf/floor/tiled/white,
 /area/exodus/medical/patient_wing)
@@ -52646,9 +52707,9 @@
 /turf/floor/tiled/white,
 /area/exodus/research/xenobiology/xenoflora_storage)
 "cfg" = (
-/obj/structure/sign/warning/biohazard,
-/turf/wall/prepainted,
-/area/exodus/research/xenobiology/xenoflora)
+/obj/machinery/light/small,
+/turf/floor/tiled/freezer,
+/area/exodus/crew_quarters/kitchen)
 "cfh" = (
 /obj/effect/floor_decal/corner/purple{
 	dir = 5
@@ -52861,9 +52922,16 @@
 /turf/wall/r_wall/prepainted,
 /area/exodus/engineering/sublevel_access)
 "cfF" = (
-/obj/structure/sign/warning/biohazard,
-/turf/wall/r_wall/prepainted,
-/area/exodus/medical/virology/access)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/floor/tiled/white,
+/area/exodus/research/xenobiology)
 "cfG" = (
 /obj/machinery/light{
 	dir = 4
@@ -52932,9 +53000,12 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/engineering/foyer)
 "cfQ" = (
-/obj/structure/sign/warning/biohazard,
-/turf/wall/r_wall/prepainted,
-/area/exodus/medical/virology)
+/obj/structure/sign/warning/docking_area{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/space,
+/area/space)
 "cfR" = (
 /obj/machinery/newscaster{
 	pixel_x = 31;
@@ -53181,6 +53252,9 @@
 /obj/effect/floor_decal/corner/lime{
 	dir = 9
 	},
+/obj/structure/sign/warning/biohazard{
+	pixel_y = -32
+	},
 /turf/floor/tiled/white,
 /area/exodus/medical/patient_wing)
 "cgs" = (
@@ -53285,9 +53359,6 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/purple{
 	dir = 5
 	},
@@ -53332,6 +53403,9 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
+/obj/structure/sign/warning/high_voltage{
+	pixel_y = 32
+	},
 /turf/floor/plating,
 /area/exodus/maintenance/research_port)
 "cgH" = (
@@ -53342,10 +53416,6 @@
 "cgI" = (
 /turf/floor/tiled/white,
 /area/exodus/research/xenobiology/xenoflora_storage)
-"cgJ" = (
-/obj/structure/sign/warning/secure_area,
-/turf/wall/r_wall/prepainted,
-/area/exodus/research/xenobiology)
 "cgK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/purple{
@@ -53386,10 +53456,6 @@
 /obj/random/tech_supply,
 /turf/floor/tiled/steel_grid,
 /area/exodus/construction)
-"cgP" = (
-/obj/structure/sign/warning/high_voltage,
-/turf/wall/r_wall/prepainted,
-/area/exodus/maintenance/starboardsolar)
 "cgQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -54605,6 +54671,7 @@
 /obj/effect/floor_decal/corner/pink/three_quarters{
 	dir = 4
 	},
+/obj/machinery/light,
 /turf/floor/tiled/white,
 /area/exodus/medical/ward)
 "cjp" = (
@@ -54663,6 +54730,9 @@
 /obj/item/radio/intercom{
 	dir = 4;
 	pixel_x = -22
+	},
+/obj/structure/sign/warning/biohazard{
+	pixel_y = 32
 	},
 /turf/floor/tiled/white,
 /area/exodus/medical/virology/access)
@@ -55183,10 +55253,6 @@
 	},
 /turf/floor/tiled/white,
 /area/exodus/research/xenobiology/xenoflora)
-"ckE" = (
-/obj/structure/sign/warning/radioactive,
-/turf/wall/r_wall/prepainted,
-/area/exodus/engineering/engine_monitoring)
 "ckF" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -55262,8 +55328,7 @@
 	department = "Science";
 	name = "Science Requests Console";
 	pixel_x = 32;
-	dir = 4;
-	
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/purple{
 	dir = 8
@@ -55422,6 +55487,10 @@
 	dir = 8
 	},
 /obj/random/closet,
+/obj/structure/sign/warning/high_voltage{
+	dir = 4;
+	pixel_x = -32
+	},
 /turf/floor/plating,
 /area/exodus/maintenance/engi_engine)
 "cle" = (
@@ -55576,10 +55645,6 @@
 	dir = 8
 	},
 /turf/floor/plating,
-/area/exodus/maintenance/substation/engineering)
-"clw" = (
-/obj/structure/sign/warning/high_voltage,
-/turf/wall/prepainted,
 /area/exodus/maintenance/substation/engineering)
 "clx" = (
 /obj/structure/disposalpipe/segment{
@@ -55772,6 +55837,7 @@
 	use_power = 1
 	},
 /obj/structure/sign/warning/vacuum{
+	dir = 8;
 	pixel_x = 32
 	},
 /turf/floor/reinforced,
@@ -55803,6 +55869,9 @@
 /obj/effect/floor_decal/corner/lime{
 	dir = 8
 	},
+/obj/structure/sign/warning/biohazard{
+	pixel_y = -32
+	},
 /turf/floor/tiled/white,
 /area/exodus/medical/virology/access)
 "clQ" = (
@@ -55812,6 +55881,9 @@
 	pixel_x = 24
 	},
 /obj/effect/floor_decal/corner/lime,
+/obj/structure/sign/warning/biohazard{
+	pixel_y = -32
+	},
 /turf/floor/tiled/white,
 /area/exodus/medical/virology/access)
 "clS" = (
@@ -56153,8 +56225,7 @@
 	department = "Engineering";
 	name = "Engineering RC";
 	pixel_y = -32;
-	dir = 2;
-	
+	dir = 2
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/engineering/foyer)
@@ -56222,6 +56293,10 @@
 	},
 /obj/effect/floor_decal/corner/yellow/three_quarters{
 	dir = 4
+	},
+/obj/structure/sign/warning/secure_area{
+	dir = 1;
+	pixel_y = -32
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/engineering/foyer)
@@ -56660,9 +56735,15 @@
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/engineering)
 "cnJ" = (
-/obj/structure/sign/warning/secure_area,
-/turf/wall/r_wall/prepainted,
-/area/exodus/engineering/engineering_monitoring)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/sign/warning/high_voltage{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/floor/tiled/steel_grid,
+/area/exodus/engineering)
 "cnK" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
@@ -56678,9 +56759,12 @@
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/engineering/workshop)
 "cnM" = (
-/obj/structure/sign/warning/secure_area,
-/turf/wall/r_wall/prepainted,
-/area/exodus/engineering/workshop)
+/obj/structure/lattice,
+/obj/structure/sign/warning/docking_area{
+	pixel_y = 32
+	},
+/turf/space,
+/area/space)
 "cnN" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/glass,
@@ -56715,6 +56799,10 @@
 /obj/structure/table,
 /obj/item/bonesetter,
 /obj/item/bonegel,
+/obj/machinery/status_display{
+	pixel_y = -32;
+	dir = 1
+	},
 /turf/floor/tiled/white/monotile,
 /area/exodus/medical/surgery)
 "cnT" = (
@@ -56800,6 +56888,10 @@
 /obj/structure/table,
 /obj/item/bonesetter,
 /obj/item/bonegel,
+/obj/machinery/status_display{
+	pixel_y = -32;
+	dir = 1
+	},
 /turf/floor/tiled/white/monotile,
 /area/exodus/medical/surgery2)
 "cod" = (
@@ -56839,6 +56931,9 @@
 	},
 /obj/effect/floor_decal/corner/lime{
 	dir = 4
+	},
+/obj/structure/sign/warning/biohazard{
+	pixel_y = 32
 	},
 /turf/floor/tiled/white,
 /area/exodus/medical/virology/access)
@@ -57194,9 +57289,6 @@
 /obj/item/chems/ivbag/blood,
 /obj/item/chems/ivbag/blood,
 /obj/structure/table,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
@@ -57275,9 +57367,12 @@
 /turf/floor/plating,
 /area/exodus/research/xenobiology)
 "cpc" = (
-/obj/machinery/status_display,
-/turf/wall/prepainted,
-/area/exodus/medical/surgery)
+/obj/structure/sign/warning/internals_required{
+	dir = 8;
+	pixel_x = 32
+	},
+/turf/floor/plating,
+/area/exodus/maintenance/security_starboard)
 "cpd" = (
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
@@ -57311,9 +57406,11 @@
 /turf/floor/tiled/white,
 /area/exodus/research/xenobiology)
 "cph" = (
-/obj/machinery/status_display,
-/turf/wall/prepainted,
-/area/exodus/medical/surgery2)
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/floor/tiled/dark,
+/area/exodus/chapel/main)
 "cpi" = (
 /obj/machinery/space_heater,
 /turf/floor/plating,
@@ -57429,9 +57526,6 @@
 	pixel_x = -25;
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/floor/tiled/white,
 /area/exodus/medical/sleeper)
 "cpz" = (
@@ -57484,9 +57578,6 @@
 /turf/floor/tiled/white,
 /area/exodus/medical/virology)
 "cpI" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -29;
 	dir = 4
@@ -57698,6 +57789,9 @@
 /obj/item/chems/ivbag/blood/oplus,
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/medical/surgeryprep)
@@ -58201,6 +58295,9 @@
 	},
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/floor/tiled/white,
 /area/exodus/medical/virology)
@@ -58814,9 +58911,6 @@
 /turf/floor/tiled/white,
 /area/exodus/crew_quarters/heads/hor)
 "ctA" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/power/apc/high{
 	dir = 1;
 	name = "north bump";
@@ -59483,6 +59577,7 @@
 /obj/item/chems/spray/pepper,
 /obj/item/chems/spray/pepper,
 /obj/item/chems/spray/pepper,
+/obj/machinery/light,
 /turf/floor/tiled/steel_grid,
 /area/exodus/security/warden)
 "cuZ" = (
@@ -59813,6 +59908,9 @@
 /obj/effect/floor_decal/corner/purple{
 	dir = 6
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/floor/tiled/white,
 /area/exodus/research/xenobiology)
 "cwf" = (
@@ -60025,8 +60123,7 @@
 	department = "Research Director's Desk";
 	name = "Research Director RC";
 	pixel_x = 32;
-	dir = 4;
-	
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -60320,8 +60417,7 @@
 	department = "Virology";
 	name = "Virology Requests Console";
 	pixel_x = -32;
-	dir = 8;
-	
+	dir = 8
 	},
 /obj/structure/table/glass,
 /obj/effect/floor_decal/corner/lime{
@@ -60411,8 +60507,7 @@
 	department = "Engineering";
 	name = "Engineering RC";
 	pixel_y = -32;
-	dir = 2;
-	
+	dir = 2
 	},
 /obj/structure/reagent_dispensers/watertank,
 /turf/floor/tiled/steel_grid,
@@ -60672,12 +60767,20 @@
 	id_tag = "exodus_rescue_shuttle_dock_inner";
 	name = "Docking Port Airlock"
 	},
+/obj/structure/sign/warning/airlock{
+	pixel_y = -32;
+	dir = 1
+	},
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/hallway/secondary/entry/aft)
 "cAp" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
+	},
+/obj/machinery/status_display{
+	pixel_y = -32;
+	dir = 1
 	},
 /turf/floor/tiled/white,
 /area/exodus/medical/virology)
@@ -60915,6 +61018,10 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/structure/sign/warning/secure_area{
+	pixel_x = 32;
+	dir = 8
+	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/engineering)
 "cCz" = (
@@ -60969,6 +61076,7 @@
 "cCP" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/light,
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/secondary/entry/fore)
 "cCR" = (
@@ -61079,10 +61187,6 @@
 /turf/floor/plating,
 /area/exodus/engineering/drone_fabrication)
 "cDk" = (
-/turf/wall/r_wall/prepainted,
-/area/exodus/engineering/engine_smes)
-"cDl" = (
-/obj/structure/sign/warning/high_voltage,
 /turf/wall/r_wall/prepainted,
 /area/exodus/engineering/engine_smes)
 "cDm" = (
@@ -62304,9 +62408,12 @@
 /turf/floor/plating,
 /area/exodus/engineering/engine_room)
 "cJa" = (
-/obj/structure/sign/warning/high_voltage,
-/turf/wall/r_wall/prepainted,
-/area/exodus/maintenance/portsolar)
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
+/turf/floor/plating,
+/area/exodus/hallway/primary/central_two)
 "cJb" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -63566,6 +63673,9 @@
 /obj/machinery/vending/cola{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/floor/tiled/monotile,
 /area/exodus/hallway/primary/central_two)
 "gwY" = (
@@ -63683,6 +63793,9 @@
 /obj/machinery/door/window{
 	dir = 4;
 	name = "High-Risk Modules"
+	},
+/obj/machinery/status_display{
+	pixel_y = 32
 	},
 /turf/floor/bluegrid,
 /area/exodus/turret_protected/ai_upload)
@@ -64169,10 +64282,6 @@
 	},
 /turf/floor/plating,
 /area/exodus/engineering/storage)
-"otj" = (
-/obj/structure/sign/warning/airlock,
-/turf/wall/prepainted,
-/area/exodus/quartermaster/miningdock)
 "ouk" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -64216,8 +64325,7 @@
 /obj/machinery/network/requests_console{
 	department = "Arrival shuttle";
 	pixel_y = -32;
-	dir = 2;
-	
+	dir = 2
 	},
 /obj/effect/floor_decal/corner/white{
 	dir = 10
@@ -64715,6 +64823,10 @@
 /area/space)
 "uKl" = (
 /obj/effect/floor_decal/corner/yellow/three_quarters,
+/obj/structure/sign/warning/secure_area{
+	dir = 1;
+	pixel_y = -32
+	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/engineering/foyer)
 "uRH" = (
@@ -64763,6 +64875,10 @@
 /obj/machinery/computer/shuttle_control/mining{
 	dir = 4
 	},
+/obj/structure/sign/warning/airlock{
+	pixel_x = -32;
+	dir = 4
+	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
 "vKw" = (
@@ -64804,6 +64920,10 @@
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
+	},
+/obj/structure/sign/warning/docking_area{
+	dir = 1;
+	pixel_y = -32
 	},
 /turf/floor,
 /area/exodus/quartermaster/miningdock)
@@ -72810,14 +72930,14 @@ cex
 cec
 cLU
 aaf
-aIo
+apc
+aGy
 aph
 aph
 aph
 aph
-aph
-aph
-aIo
+aDe
+apc
 aaf
 aKz
 aLE
@@ -74090,7 +74210,7 @@ cLU
 cLU
 cLU
 cec
-buv
+bvY
 awH
 azh
 atS
@@ -74376,7 +74496,7 @@ cLU
 cLU
 cLU
 cLU
-bcy
+bgo
 aaf
 crP
 cLU
@@ -74627,13 +74747,13 @@ cLU
 cLU
 cLU
 cLU
-bcy
-cLU
-cLU
-cLU
-cLU
-cLU
 bgo
+cLU
+cLU
+cLU
+cLU
+cLU
+bIQ
 cLU
 crP
 cLU
@@ -74884,7 +75004,7 @@ cLU
 cLU
 cLU
 cLU
-bgo
+bIQ
 cLU
 cLU
 cLU
@@ -76178,7 +76298,7 @@ cLU
 aCj
 czq
 cAk
-aTw
+aCj
 cLU
 cLU
 cLU
@@ -76679,20 +76799,20 @@ aDq
 aVj
 axF
 aaf
-aTw
+aCj
 aNl
 aCj
 aaf
 bgo
 aaf
-aTw
+aCj
 aOd
 aCj
 cLU
 aCj
 bgw
 bsP
-aCj
+bGB
 cLU
 cLU
 cLU
@@ -76913,7 +77033,7 @@ atX
 atX
 ajN
 atq
-avy
+asA
 avM
 axx
 atZ
@@ -76949,7 +77069,7 @@ aCj
 aCj
 bgw
 bsP
-bcy
+bgo
 cLU
 cLU
 cLU
@@ -77941,7 +78061,7 @@ aud
 aud
 avf
 atq
-avy
+asA
 awJ
 ayo
 auN
@@ -80009,7 +80129,7 @@ bsi
 bke
 awV
 axJ
-aIE
+aIA
 aJO
 aLz
 aLz
@@ -80266,7 +80386,7 @@ aCy
 aDX
 cxb
 bdw
-aIF
+aIA
 aJQ
 aLA
 aNf
@@ -80302,8 +80422,8 @@ aQh
 aQh
 aQh
 aQh
-aIo
-cLU
+apc
+aGX
 cLU
 cLU
 cLU
@@ -80546,7 +80666,7 @@ aHq
 bnY
 bqK
 aKJ
-aaf
+cnM
 cLU
 cLU
 cLU
@@ -81059,7 +81179,7 @@ bmo
 bmW
 bmW
 bqM
-bnP
+brG
 cLU
 cLU
 cLU
@@ -81293,7 +81413,7 @@ awD
 avi
 awf
 awZ
-baz
+aFC
 aHU
 aJG
 aFC
@@ -81548,7 +81668,7 @@ aoN
 aAH
 aBS
 aAs
-aDZ
+aAF
 aFh
 aIK
 ayN
@@ -82087,7 +82207,7 @@ beG
 beG
 bbZ
 bkW
-bnP
+brG
 cLU
 cLU
 cLU
@@ -82602,15 +82722,15 @@ brG
 brG
 bkW
 baj
-aap
+bXZ
 cLU
-bpf
+aLF
 aQC
 aRB
-bpf
+aLF
 aRB
 aRF
-bpf
+aLF
 cLU
 bqY
 apc
@@ -82625,8 +82745,8 @@ aQh
 aQh
 aQh
 aQh
-aIo
-cLU
+apc
+aGX
 cLU
 cLU
 cLU
@@ -84645,7 +84765,7 @@ aLK
 aTM
 aTM
 aWR
-aTM
+blQ
 bao
 bbP
 bdB
@@ -84670,11 +84790,11 @@ aLF
 cLU
 cLU
 cLU
-bUb
+aSC
 bNg
 hbt
 wiC
-bUb
+aSC
 aaf
 aaf
 cLU
@@ -85187,7 +85307,7 @@ bGt
 bGt
 bGt
 fmR
-otj
+bGt
 bGt
 bGt
 aaf
@@ -85663,7 +85783,7 @@ aCC
 gcu
 gcu
 aFv
-aIQ
+aBY
 atU
 axk
 aNs
@@ -86177,7 +86297,7 @@ biX
 gcu
 gcu
 aFy
-aIQ
+aBY
 atU
 axk
 aNr
@@ -87434,7 +87554,7 @@ adE
 adE
 adE
 adE
-ajl
+adE
 agc
 agD
 agQ
@@ -87485,7 +87605,7 @@ blm
 bfm
 bqk
 brm
-btz
+bfm
 buP
 bwo
 bwo
@@ -87970,9 +88090,9 @@ aie
 anX
 axM
 apD
+aBM
+aBM
 aAB
-aBM
-aBM
 arS
 aCP
 aGl
@@ -88005,8 +88125,8 @@ bwr
 aMh
 aMh
 bBv
-aMh
-bGi
+aee
+bGv
 bGv
 aQO
 aQO
@@ -88998,9 +89118,9 @@ awy
 atc
 axM
 apD
+aBM
+aBM
 aAG
-aBM
-aBM
 asu
 aCQ
 aGS
@@ -89735,11 +89855,11 @@ acf
 abe
 aaf
 aaf
-aat
-aat
-aat
-aat
-aat
+aeW
+aeW
+aeW
+aeW
+aeW
 aeW
 afZ
 aha
@@ -89858,7 +89978,7 @@ cGR
 cGR
 cLU
 cIK
-cJa
+cIK
 cJG
 cIK
 cIK
@@ -89992,7 +90112,7 @@ abz
 abe
 acm
 cLU
-aat
+aeW
 aoq
 aoq
 aoq
@@ -90249,7 +90369,7 @@ aci
 acB
 abd
 cLU
-aat
+aeW
 aoq
 aoq
 aoq
@@ -90310,7 +90430,7 @@ aEK
 bdY
 bmG
 bmG
-aJu
+bmG
 aHB
 bmG
 bmG
@@ -90320,7 +90440,7 @@ aLR
 aLR
 aLR
 bEw
-bGB
+btC
 ixD
 bJl
 bKL
@@ -90506,7 +90626,7 @@ abY
 acx
 abd
 cLU
-aat
+aeW
 aoq
 aoq
 aoq
@@ -90763,7 +90883,7 @@ abV
 acz
 abd
 cLU
-aat
+aeW
 aoq
 aoq
 aoq
@@ -91015,7 +91135,7 @@ cLU
 cLU
 aaf
 abd
-abr
+abd
 acb
 abd
 abd
@@ -91612,9 +91732,9 @@ bHM
 btC
 bNy
 aSX
-bQC
+aVv
 bUo
-bTr
+aVv
 aSX
 bNy
 aVv
@@ -92090,7 +92210,7 @@ aIH
 azS
 ayL
 aKx
-axB
+auk
 aNL
 aPv
 eEV
@@ -92294,8 +92414,8 @@ cLU
 crP
 aaf
 aaf
-aaA
-cLU
+aah
+bnj
 cLU
 abh
 abg
@@ -92580,7 +92700,7 @@ akJ
 akF
 amm
 apw
-aoF
+atx
 ajG
 alx
 amw
@@ -92928,8 +93048,8 @@ cmv
 cyV
 bql
 bUh
-bUC
-cDl
+cnJ
+cDk
 bZh
 bZC
 cai
@@ -93122,7 +93242,7 @@ aQI
 aNF
 aPy
 aQK
-aLO
+azb
 aAJ
 aVR
 aVR
@@ -93186,7 +93306,7 @@ bsq
 bql
 bUp
 bXH
-ckE
+cDJ
 cDJ
 cDJ
 cbA
@@ -93394,13 +93514,13 @@ bkn
 blA
 blR
 bFo
-bpK
+beb
 bsB
 btL
 bvH
 rwB
 bxr
-bFv
+bAh
 bBC
 bAh
 bAh
@@ -93421,14 +93541,14 @@ bYS
 cah
 cbF
 ccR
-cez
+cbF
 cbF
 cht
 cbF
 cbF
 cbF
 uKl
-cnJ
+cnG
 bjV
 bLn
 bLn
@@ -94415,20 +94535,20 @@ aYZ
 aUp
 aaf
 beb
-bfv
+abr
 bgy
 bgy
 bgx
 blA
 blT
 bGf
-bnj
+beb
 hDm
 btL
 bvN
 bxo
 bxr
-bIQ
+bAj
 bBH
 bAj
 bAj
@@ -94456,7 +94576,7 @@ ced
 cjY
 cli
 cmJ
-cnM
+cnO
 bkA
 bkA
 bkA
@@ -94664,7 +94784,7 @@ aLQ
 aKF
 aPu
 eEV
-aLO
+azb
 aAZ
 aVR
 aVR
@@ -94728,7 +94848,7 @@ cyZ
 bkA
 cdJ
 bYF
-ckE
+cDJ
 cDJ
 cDJ
 cDJ
@@ -94913,7 +95033,7 @@ aoH
 aoH
 aoH
 aCu
-aDe
+aCu
 aHc
 aCu
 auk
@@ -95382,7 +95502,7 @@ cLU
 aaG
 aaC
 aaL
-aaC
+bvP
 aba
 abE
 abR
@@ -95641,7 +95761,7 @@ aaD
 aaL
 aaU
 abj
-abI
+abF
 acc
 acw
 acw
@@ -95941,7 +96061,7 @@ avW
 atE
 atE
 aCu
-aDe
+aCu
 axO
 aCu
 gsd
@@ -96423,8 +96543,8 @@ afa
 afw
 adq
 agp
-acC
-ahe
+acT
+bUb
 ahI
 aiR
 aiQ
@@ -96936,7 +97056,7 @@ aeb
 afa
 afw
 adq
-agE
+aIQ
 acT
 ahe
 ahL
@@ -97795,7 +97915,7 @@ caq
 caq
 ciA
 ciA
-clw
+ciA
 coy
 cgs
 cpj
@@ -98064,7 +98184,7 @@ cuC
 bPx
 bLm
 bLm
-bLm
+baA
 cBA
 bLm
 cis
@@ -98216,8 +98336,8 @@ abp
 abb
 adj
 adl
+cpc
 adl
-aee
 aeR
 afl
 afA
@@ -98233,7 +98353,7 @@ alf
 abb
 anQ
 anQ
-and
+anQ
 aoC
 anQ
 aoH
@@ -98262,8 +98382,8 @@ aJl
 aOc
 aPH
 aLY
+bpK
 aLY
-aUj
 aLY
 aLY
 aLY
@@ -98485,7 +98605,7 @@ abp
 abp
 abp
 abb
-ajk
+agm
 akZ
 aln
 amx
@@ -98520,8 +98640,8 @@ aJl
 aGJ
 aJl
 aJl
-aPr
-aBu
+aJl
+cJa
 aJl
 aBu
 aJl
@@ -98529,7 +98649,7 @@ aBu
 aJl
 aJl
 biO
-bia
+aYT
 bkP
 aJl
 aJl
@@ -98826,7 +98946,7 @@ ciS
 ciS
 ciS
 cnS
-cpc
+ciG
 cqi
 cro
 csD
@@ -99064,7 +99184,7 @@ bsc
 bEN
 bLR
 bDt
-bEL
+abI
 bEL
 bEL
 bTs
@@ -99313,8 +99433,8 @@ bxa
 byr
 bAg
 bBU
-bDv
-bEN
+bDt
+bpf
 bGA
 bDt
 cpw
@@ -99565,9 +99685,9 @@ bnN
 bpT
 brM
 btt
-bwD
+buc
+cez
 bwZ
-byt
 bAf
 byt
 bDn
@@ -100084,7 +100204,7 @@ bxC
 bxC
 bkc
 bxC
-bDy
+bxC
 bEO
 bGD
 bxC
@@ -100341,7 +100461,7 @@ bxe
 byx
 bAm
 bBZ
-bDp
+avy
 bER
 bGI
 bIk
@@ -100583,8 +100703,8 @@ aZm
 aZA
 aSS
 bcN
-bfQ
-dxK
+aZz
+ceW
 bii
 bjw
 aZz
@@ -100844,7 +100964,7 @@ aZz
 dxK
 bii
 bjz
-bhM
+aZz
 bmf
 bnU
 bnX
@@ -101100,8 +101220,8 @@ btA
 aZz
 dxK
 bii
-iYA
-blQ
+aIF
+aZz
 bmb
 bnU
 bnX
@@ -101353,9 +101473,9 @@ aTX
 aTX
 aSS
 aSS
-aTk
-aYT
-dxK
+ajk
+aZz
+ccd
 bik
 bjC
 bkX
@@ -101384,7 +101504,7 @@ bTJ
 bSJ
 bWk
 bXE
-bZq
+bTJ
 caL
 cbT
 cdq
@@ -101858,7 +101978,7 @@ aLd
 aKS
 aMt
 aGD
-aMs
+cfg
 aKZ
 aUn
 aUx
@@ -101871,8 +101991,8 @@ beZ
 aZz
 dxK
 bii
-rkN
-blQ
+aIE
+aZz
 bmb
 bnX
 bnX
@@ -101910,7 +102030,7 @@ cjc
 cjc
 cjc
 coc
-cph
+ciU
 cqq
 crB
 csK
@@ -102129,7 +102249,7 @@ aZz
 bgH
 bii
 bjD
-bhM
+aZz
 bmw
 bnX
 bnX
@@ -102902,7 +103022,7 @@ bim
 rkN
 aZz
 bni
-biW
+bni
 bqe
 bni
 bni
@@ -103197,7 +103317,7 @@ clN
 clN
 clN
 clN
-cfQ
+cqv
 cqv
 cqv
 cqv
@@ -103450,7 +103570,7 @@ ccP
 cjh
 bPl
 clP
-cfF
+clN
 cjt
 coX
 cqu
@@ -103658,8 +103778,8 @@ aLf
 aMF
 aOs
 aPR
-aPR
-aTa
+aDZ
+aKZ
 aUt
 aMw
 aTs
@@ -103964,7 +104084,7 @@ ccP
 cji
 bQz
 clQ
-cfF
+clN
 cof
 coX
 cqz
@@ -104225,7 +104345,7 @@ clN
 clN
 clN
 clN
-cfQ
+cqv
 cqv
 ctF
 ctF
@@ -105735,7 +105855,7 @@ bov
 bua
 aXK
 aXK
-baA
+aXK
 bBJ
 aXK
 bBT
@@ -105777,7 +105897,7 @@ btn
 ceC
 cpH
 cAp
-bvP
+bmh
 cLU
 cLU
 cLU
@@ -106273,7 +106393,7 @@ bpW
 bTl
 bXU
 car
-car
+bnP
 cca
 bXj
 bQD
@@ -106507,7 +106627,7 @@ bYf
 aXK
 aXK
 bAs
-baA
+aXK
 aXK
 bCp
 bFh
@@ -106805,7 +106925,7 @@ cpt
 ceC
 cpH
 cAp
-bvP
+bmh
 cLU
 cqD
 aaf
@@ -107556,7 +107676,7 @@ bZK
 caJ
 cce
 cdH
-ccd
+bYc
 cgG
 bYf
 cjl
@@ -107810,7 +107930,7 @@ bVg
 bWD
 bXW
 bZM
-bXZ
+bXY
 ccs
 cdG
 cgR
@@ -107823,8 +107943,8 @@ aZT
 cLU
 cLU
 cLU
-cLU
-cfQ
+aTw
+cqv
 cqv
 cqv
 cqv
@@ -108275,7 +108395,7 @@ aoJ
 aAk
 aDB
 aDY
-aGy
+aCv
 aED
 aDC
 aDC
@@ -108815,7 +108935,7 @@ blO
 bne
 boI
 bqu
-boI
+aJu
 buf
 bvB
 boI
@@ -110391,8 +110511,8 @@ ckz
 cif
 com
 col
-crQ
-crQ
+bfQ
+bwv
 crQ
 crQ
 czP
@@ -110616,7 +110736,7 @@ blO
 brh
 brh
 brh
-bwv
+brh
 bpp
 bpp
 aLr
@@ -110644,7 +110764,7 @@ cdO
 aZb
 chS
 bNq
-ceW
+com
 com
 com
 com
@@ -110858,7 +110978,7 @@ aRo
 aHA
 aUP
 aWs
-aHA
+cph
 aZs
 bbp
 bcR
@@ -110897,7 +111017,7 @@ aWW
 bww
 bJE
 cdR
-bXx
+cdO
 bce
 chR
 bLO
@@ -111159,7 +111279,7 @@ bIa
 bKw
 bPa
 aIu
-bVK
+cfF
 bVK
 bVP
 aYB
@@ -111411,7 +111531,7 @@ aWX
 bww
 bkj
 cdU
-cgJ
+cdO
 bce
 bJN
 bNS
@@ -111672,7 +111792,7 @@ cdO
 aZP
 bKB
 bSY
-cfg
+bdX
 bdX
 bdX
 com
@@ -115752,8 +115872,8 @@ cLU
 cLU
 cLU
 cLU
-cLU
-blM
+cfQ
+bjl
 bjl
 bjl
 bjl
@@ -115781,7 +115901,7 @@ bUn
 ccv
 cDE
 bOo
-cgP
+cgN
 chG
 cjx
 cfl

--- a/maps/exodus/exodus_define.dm
+++ b/maps/exodus/exodus_define.dm
@@ -12,8 +12,11 @@
 	company_short = "NT"
 	system_name   = "Nyx"
 
+	default_law_type = /datum/ai_laws/nanotrasen
+
 	overmap_ids = list(OVERMAP_ID_SPACE)
-	num_exoplanets = 1
+	num_exoplanets = 3
+	away_site_budget = 3
 
 	lobby_screens = list(
 		'maps/exodus/lobby/exodus.png'


### PR DESCRIPTION
## Description of changes
Misc Fixes and Adjustments of the Exodus map so it can be used for the upcoming Polaris Playtest. 

## Why and what will this PR improve
Current Exodus map is playable but rather mothballed. Most of tweaks are personal preferences and some minor bug fixes that I feel should help players be a bit more comfortable as we play. Since none of the other maps currently available are close to what we currently have or could be considered playable aside from Tradeship. This should not be forwarded up to Neb as the job done here was poor in terms of fixes, but should be good enough for us to playtest and fiddle around on.

## Authorship
Woodrat

## Changelog
:cl:
bugfix: Fixed two areas to prevent vented rooms at roundstart.
bugfix: Fixed several status displays that were stuck in the contents of walls.
bugfix: Bodge fix smartfridges/wall lockers being inaccessible within walls (moved them).
bugfix: Bodge fix of portable flashers being offset.
tweak: Adjusts positions of several lights around the map to look less messy and removed a few redundant ones.
tweak: Adjusts positions of several signs to look less messy.
tweak: Adjusts main station SMES to last roughly 30-40 minutes of playtime from the 8-10 minutes it currently runs at.
tweak: AI now has corporate lawset (NT) rather than Asimov.
add: Added two more exoplanets and three space based away missions for potential to look at and explore for playtest.
/:cl: