### PR TITLE
PolNeb Exodus Tweaks Again.

### DIFF
--- a/maps/exodus/exodus-2.dmm
+++ b/maps/exodus/exodus-2.dmm
@@ -2024,6 +2024,8 @@
 /obj/machinery/vending/wallmed1{
 	pixel_x = -26
 	},
+/obj/item/gps,
+/obj/item/gps,
 /turf/floor/tiled/steel_grid,
 /area/exodus/security/main)
 "aev" = (
@@ -30853,6 +30855,9 @@
 	dir = 4
 	},
 /obj/structure/table,
+/obj/item/gps/science,
+/obj/item/gps/science,
+/obj/item/gps/science,
 /turf/floor/tiled/white,
 /area/exodus/research)
 "bnr" = (
@@ -30866,7 +30871,10 @@
 /turf/floor/carpet,
 /area/exodus/crew_quarters/captain)
 "bns" = (
-/obj/machinery/door/airlock/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	autoset_access = 0;
+	req_access = list(list(access_maint_tunnels, access_emergency_storage, access_research))
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -32724,6 +32732,10 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
+/obj/structure/table{
+	name = "plastic table frame"
+	},
+/obj/machinery/recharger,
 /turf/floor/plating,
 /area/ship/exodus_pod_research)
 "brh" = (
@@ -33207,6 +33219,8 @@
 /obj/item/roller,
 /obj/item/rig/medical/equipped,
 /obj/item/defibrillator/compact/loaded,
+/obj/item/gps/medical,
+/obj/item/gps/medical,
 /turf/floor/tiled/white,
 /area/exodus/medical/sleeper)
 "bsd" = (
@@ -34025,6 +34039,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/item/gun/energy/captain,
 /turf/floor/carpet,
 /area/exodus/crew_quarters/captain)
 "btR" = (
@@ -37685,7 +37700,9 @@
 /area/exodus/security/prison/dorm)
 "bBd" = (
 /obj/machinery/door/airlock{
-	name = "Starboard Emergency Storage"
+	name = "Starboard Emergency Storage";
+	autoset_access = 0;
+	req_access = list(list(access_maint_tunnels, access_emergency_storage, access_research))
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -38270,12 +38287,16 @@
 /turf/floor/tiled/white,
 /area/exodus/research/xenobiology)
 "bCr" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/floor/plating,
+/obj/machinery/network/relay/long_range,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/floor/tiled/white,
 /area/ship/exodus_pod_research)
 "bCs" = (
 /obj/structure/table,
@@ -39761,8 +39782,11 @@
 /turf/floor/tiled/white,
 /area/exodus/research)
 "bFr" = (
-/obj/machinery/door/airlock/maintenance,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance{
+	autoset_access = 0;
+	req_access = list(list(access_maint_tunnels, access_research))
+	},
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/maintenance/research_shuttle)
 "bFs" = (
@@ -39826,7 +39850,10 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/port)
 "bFy" = (
-/obj/machinery/door/airlock/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	autoset_access = 0;
+	req_access = list(list(access_maint_tunnels, access_research))
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -42083,7 +42110,6 @@
 /area/exodus/research/xenobiology)
 "bJF" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -42092,6 +42118,10 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/maintenance{
+	autoset_access = 0;
+	req_access = list(list(access_maint_tunnels, access_research))
 	},
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/maintenance/research_port)
@@ -45217,9 +45247,12 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/maintenance{
+	autoset_access = 0;
+	req_access = list(list(access_maint_tunnels, access_research))
+	},
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/maintenance/research_shuttle)
 "bQa" = (
@@ -45784,6 +45817,7 @@
 	pixel_y = 24
 	},
 /obj/structure/table/reinforced,
+/obj/item/gps,
 /turf/floor/tiled/steel_grid,
 /area/exodus/engineering/engineering_monitoring)
 "bRg" = (
@@ -46235,6 +46269,7 @@
 	dir = 10
 	},
 /obj/item/rig/industrial/equipped,
+/obj/item/gps/mining,
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
 "bRW" = (
@@ -48777,9 +48812,12 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance{
+	autoset_access = 0;
+	req_access = list(list(access_maint_tunnels, access_research))
+	},
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/maintenance/research_starboard)
 "bXr" = (
@@ -63024,12 +63062,16 @@
 /turf/floor/plating,
 /area/exodus/maintenance/portsolar)
 "cLt" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/turf/floor/plating,
+/obj/machinery/network/relay/long_range,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/floor/tiled/dark,
 /area/ship/exodus_pod_engineering)
 "cLu" = (
 /obj/structure/bed/chair{
@@ -63565,8 +63607,14 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/turf/floor/plating,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/network/relay/long_range,
+/turf/floor/tiled/steel_grid,
 /area/ship/exodus_pod_mining)
 "fmR" = (
 /obj/machinery/door/airlock/external/bolted{
@@ -64231,6 +64279,17 @@
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/storage)
+"nLD" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/structure/table{
+	name = "plastic table frame"
+	},
+/obj/machinery/recharger,
+/turf/floor,
+/area/ship/exodus_pod_mining)
 "nOM" = (
 /obj/effect/floor_decal/corner/white{
 	dir = 6
@@ -64452,7 +64511,6 @@
 /area/exodus/hallway/primary/starboard)
 "roQ" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -64461,6 +64519,10 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/maintenance{
+	autoset_access = 0;
+	req_access = list(list(access_maint_tunnels, access_research))
 	},
 /turf/floor/plating,
 /area/exodus/maintenance/research_starboard)
@@ -64679,6 +64741,13 @@
 	},
 /turf/floor/plating,
 /area/ship/exodus_pod_mining)
+"tsZ" = (
+/obj/effect/floor_decal/spline/plain,
+/obj/structure/hygiene/faucet{
+	dir = 1
+	},
+/turf/floor/pool,
+/area/exodus/crew_quarters/fitness)
 "tuN" = (
 /obj/machinery/light{
 	dir = 8
@@ -64687,6 +64756,11 @@
 /obj/effect/floor_decal/corner/white/three_quarters,
 /turf/floor/tiled/dark/monotile,
 /area/shuttle/arrival/station)
+"tvx" = (
+/obj/effect/floor_decal/spline/plain,
+/obj/structure/hygiene/drain/bath,
+/turf/floor/pool,
+/area/exodus/crew_quarters/fitness)
 "tzU" = (
 /obj/machinery/computer/ship/sensors{
 	dir = 1
@@ -64888,6 +64962,11 @@
 	},
 /turf/floor/plating,
 /area/space)
+"vPY" = (
+/obj/structure/table/reinforced,
+/obj/item/gps,
+/turf/floor/tiled/steel_grid,
+/area/exodus/engineering/engineering_monitoring)
 "vRS" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -83508,7 +83587,7 @@ bNr
 dkO
 idh
 tGf
-vRS
+nLD
 lDi
 vRS
 rVT
@@ -92521,7 +92600,7 @@ cjT
 cgo
 cmC
 cnG
-coG
+vPY
 bVY
 cnz
 coD
@@ -99907,7 +99986,7 @@ akq
 atP
 auX
 auX
-crV
+tsZ
 axA
 ayg
 ayY
@@ -100421,7 +100500,7 @@ aqB
 atP
 aBl
 auX
-crV
+tvx
 axA
 ayg
 azc

--- a/maps/exodus/jobs/medical.dm
+++ b/maps/exodus/jobs/medical.dm
@@ -55,6 +55,7 @@
 	outfit_type = /decl/outfit/job/medical/cmo
 	min_skill = list(
 		SKILL_LITERACY  = SKILL_ADEPT,
+		SKILL_DEVICES  = SKILL_ADEPT,
 		SKILL_MEDICAL   = SKILL_EXPERT,
 		SKILL_ANATOMY   = SKILL_EXPERT,
 		SKILL_CHEMISTRY = SKILL_BASIC
@@ -111,12 +112,14 @@
 	outfit_type = /decl/outfit/job/medical/doctor
 	min_skill = list(
 		SKILL_LITERACY = SKILL_ADEPT,
+		SKILL_DEVICES  = SKILL_ADEPT,
 		SKILL_EVA      = SKILL_BASIC,
 		SKILL_MEDICAL  = SKILL_BASIC,
 		SKILL_ANATOMY  = SKILL_BASIC
 	)
 	max_skill = list(
 		SKILL_MEDICAL   = SKILL_MAX,
+		SKILL_ANATOMY   = SKILL_MAX,
 		SKILL_CHEMISTRY = SKILL_MAX
 	)
 	software_on_spawn = list(

--- a/maps/exodus/jobs/security.dm
+++ b/maps/exodus/jobs/security.dm
@@ -33,6 +33,7 @@
 		access_RC_announce,
 		access_keycard_auth,
 		access_gateway,
+		access_emergency_storage,
 		access_external_airlocks
 	)
 	minimal_access = list(
@@ -57,6 +58,7 @@
 		access_RC_announce,
 		access_keycard_auth,
 		access_gateway,
+		access_emergency_storage,
 		access_external_airlocks
 	)
 	minimal_player_age = 14
@@ -106,6 +108,7 @@
 		access_armory,
 		access_maint_tunnels,
 		access_morgue,
+		access_emergency_storage,
 		access_external_airlocks
 	)
 	minimal_access = list(
@@ -115,6 +118,7 @@
 		access_brig,
 		access_armory,
 		access_maint_tunnels,
+		access_emergency_storage,
 		access_external_airlocks
 	)
 	minimal_player_age = 7
@@ -155,6 +159,7 @@
 		access_sec_doors,
 		access_forensics_lockers,
 		access_morgue,
+		access_emergency_storage,
 		access_maint_tunnels
 	)
 	minimal_access = list(
@@ -162,6 +167,7 @@
 		access_sec_doors,
 		access_forensics_lockers,
 		access_morgue,
+		access_emergency_storage,
 		access_maint_tunnels
 	)
 	minimal_player_age = 7
@@ -202,6 +208,7 @@
 		access_brig,
 		access_maint_tunnels,
 		access_morgue,
+		access_emergency_storage,
 		access_external_airlocks
 	)
 	minimal_access = list(
@@ -210,6 +217,7 @@
 		access_sec_doors,
 		access_brig,
 		access_maint_tunnels,
+		access_emergency_storage,
 		access_external_airlocks
 	)
 	minimal_player_age = 7


### PR DESCRIPTION
## Description of changes
Further adjustments to the Exodus map.

## Why and what will this PR improve
From notes on feedback and comments from the last playtest to tailor it more to our testing needs.

## Authorship
Woodrat

## Changelog
:cl:
add: Added Max anatomy to doctor position (previously only avail for CMO).
add: Added Devices skill min adept to doctor and cmo (supposedly so they can do prosthetic attachment).
add: GPS units to mining, science, medical, security, engineering.
add: Long Range Relays added to shuttles
add: Rechargers added to mining and science shuttle.
add: Emergency storage access to security roles.
bugfix: Fixed access on maint doors around Research.
bugfix: Missing faucet and drain added to pool.
/:cl:
