### PR TITLE
Fix paracetamol recipe

### DIFF
--- a/mods/content/baychems/reactions.dm
+++ b/mods/content/baychems/reactions.dm
@@ -30,10 +30,14 @@
 	result = /decl/material/liquid/painkillers
 	required_reagents = list(
 		/decl/material/liquid/stabilizer = 1,
-		/decl/material/gas/nitrogen = 1,
+		/decl/material/gas/ammonia = 1,
 		/decl/material/liquid/water = 1
 	)
 	result_amount = 3
+
+/decl/chemical_reaction/compound/space_cleaner/Initialize()
+	. = ..()
+	LAZYSET(inhibitors, /decl/material/liquid/stabilizer, 1) // Messes up paracetamol
 
 /decl/chemical_reaction/drug/strong_painkillers
 	name = "Tramadol"


### PR DESCRIPTION
Fixes the paracetamol recipe by reverting nitrogen back to ammonia and adding stabilizer to space cleaner's inhibitors list.