### PR TITLE
Changes a few things on the Exodus map for Polaris.

### DIFF
--- a/maps/exodus/exodus_define.dm
+++ b/maps/exodus/exodus_define.dm
@@ -23,6 +23,7 @@
 	)
 
 	evac_controller_type = /datum/evacuation_controller/shuttle
+	game_year = 552
 
 //  For /datum/evacuation_controller/shuttle
 

--- a/maps/exodus/exodus_departments.dm
+++ b/maps/exodus/exodus_departments.dm
@@ -1,6 +1,5 @@
 /decl/department/engineering
 	name = "Engineering"
-	announce_channel = "Engineering"
 	colour = "#ffa500"
 	display_priority = 4
 	display_color = "#fff5cc"
@@ -13,7 +12,6 @@
 
 /decl/department/security
 	name = "Security"
-	announce_channel = "Security"
 	colour = "#dd0000"
 	display_priority = 3
 	display_color = "#ffddf0"
@@ -21,13 +19,12 @@
 /obj/item/robot_module/security
 	associated_department = /decl/department/security
 
-/obj/machinery/network/pager/security 
+/obj/machinery/network/pager/security
 	department = /decl/department/security
 
 /decl/department/medical
 	name = "Medical"
 	goals = list(/datum/goal/department/medical_fatalities)
-	announce_channel = "Medical"
 	colour = "#008000"
 	display_priority = 2
 	display_color = "#ffeef0"
@@ -41,7 +38,6 @@
 /decl/department/science
 	name = "Science"
 	goals = list(/datum/goal/department/extract_slime_cores)
-	announce_channel = "Science"
 	colour = "#a65ba6"
 	display_color = "#e79fff"
 
@@ -72,27 +68,23 @@
 
 /decl/department/service
 	name = "Service"
-	announce_channel = "Service"
 	colour = "#88b764"
 	display_color = "#d0f0c0"
 
 /decl/department/supply
 	name = "Supply"
-	announce_channel = "Supply"
 	colour = "#bb9040"
 	display_color = "#f0e68c"
 
-/obj/machinery/network/pager/cargo 
+/obj/machinery/network/pager/cargo
 	department = /decl/department/supply
 
 /decl/department/support
 	name = "Support"
-	announce_channel = "Command"
 	colour = "#800080"
 	display_color = "#87ceeb"
 
 /decl/department/exploration
 	name = "Exploration"
-	announce_channel = "Exploration"
 	colour = "#68099e"
 	display_color = "#b784a7"


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Tweaks a few map defines to be more in line with what Polaris wants.
Specifically, the in-game year should match current Polaris code, and joining the round will announce you on Common instead of inside departmental comms.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes #64 
Fixes #68 

## Authorship
<!-- Describe original authors of changes to credit them. -->
Me

## Changelog
:cl:
tweak: Joining the round will announce on Common radio for all station roles.
tweak: The in-game year is now the same as on Polaris.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->