### PR TITLE
Yet More Exodus Map Tweaks

### DIFF
--- a/maps/exodus/exodus-2.dmm
+++ b/maps/exodus/exodus-2.dmm
@@ -1720,7 +1720,8 @@
 	id_tag = "Armoury";
 	name = "Armoury Access";
 	pixel_x = -1;
-	pixel_y = -28
+	pixel_y = -28;
+	req_access = list("ACCESS_ARMORY")
 	},
 /turf/floor/tiled/dark,
 /area/exodus/security/armoury)
@@ -1944,7 +1945,8 @@
 	id_tag = "Armoury";
 	name = "Emergency Access";
 	pixel_x = -28;
-	pixel_y = 4
+	pixel_y = 4;
+	req_access = list("ACCESS_ARMORY")
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -7232,7 +7234,6 @@
 /area/exodus/solar/auxport)
 "apl" = (
 /obj/structure/cable,
-/obj/effect/engine_setup/smes,
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Engine - Main";
 	charge = 2.5e+005;
@@ -7242,6 +7243,7 @@
 	output_level = 1e+006;
 	uncreated_component_parts = list(/obj/item/stock_parts/smes_coil/super_capacity = 4)
 	},
+/obj/effect/engine_setup/smes/main,
 /turf/floor/plating,
 /area/exodus/engineering/engine_smes)
 "apm" = (
@@ -10345,8 +10347,8 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/hologram/holopad,
 /obj/abstract/landmark/paperwork_finish_exodus,
+/obj/machinery/hologram/holopad/longrange,
 /turf/floor/tiled/steel_grid,
 /area/exodus/bridge)
 "avT" = (
@@ -10469,7 +10471,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/effect/engine_setup/smes,
+/obj/effect/engine_setup/smes/main,
 /turf/floor/plating,
 /area/exodus/engineering/engine_room)
 "awb" = (
@@ -35476,6 +35478,7 @@
 /area/exodus/maintenance/engineering)
 "bwJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red,
+/obj/machinery/hologram/holopad/longrange,
 /turf/floor/tiled/white,
 /area/ship/exodus_pod_research)
 "bwK" = (
@@ -38366,6 +38369,8 @@
 	c_tag = "Cargo Mining Dock";
 	dir = 1
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/ore_box,
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
 "bCy" = (
@@ -38956,8 +38961,8 @@
 /turf/floor/plating,
 /area/exodus/maintenance/research_port)
 "bDH" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/ore_box,
+/obj/machinery/mining/brace,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
 "bDI" = (
@@ -41752,6 +41757,7 @@
 /obj/effect/floor_decal/corner/brown/three_quarters{
 	dir = 8
 	},
+/obj/structure/ore_box,
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
 "bJa" = (
@@ -63045,6 +63051,7 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad/longrange,
 /turf/floor/tiled/dark,
 /area/ship/exodus_pod_engineering)
 "cLm" = (
@@ -63405,9 +63412,7 @@
 /turf/floor/plating,
 /area/ship/exodus_pod_research)
 "cUO" = (
-/obj/machinery/light,
-/turf/floor/tiled/steel_grid,
-/area/exodus/quartermaster/miningdock)
+)
 "cYR" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
@@ -64057,6 +64062,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad/longrange,
 /turf/floor/tiled/steel_grid,
 /area/ship/exodus_pod_mining)
 "idY" = (
@@ -64374,6 +64380,12 @@
 	},
 /turf/floor/tiled/white,
 /area/ship/exodus_pod_research)
+"lHF" = (
+/obj/machinery/light,
+/obj/machinery/mining/drill,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/floor/tiled/steel_grid,
+/area/exodus/quartermaster/miningdock)
 "miB" = (
 /obj/structure/cable/green,
 /obj/machinery/ion_thruster{
@@ -83417,6 +83429,8 @@ cLU
 cLU
 cLU
 cLU
+cUO
+cUO
 "}
 (70,1,1) = {"
 cLU
@@ -86908,8 +86922,8 @@ bWo
 gdx
 jfD
 bPc
+bKK
 bCx
-bGt
 bGt
 cLU
 cLU
@@ -87679,8 +87693,8 @@ bGt
 bMj
 bJb
 buo
-cUO
-bGt
+bKK
+lHF
 bGt
 aaf
 cLU

--- a/maps/exodus/exodus_areas.dm
+++ b/maps/exodus/exodus_areas.dm
@@ -510,7 +510,6 @@
 
 /area/exodus/security/brig
 	name = "\improper Security - Brig"
-	req_access = list(access_brig)
 
 /area/exodus/security/brig/processing
 	name = "\improper Security - Processing"
@@ -523,10 +522,12 @@
 /area/exodus/security/brig/solitaryA
 	name = "\improper Security - Solitary 1"
 	icon_state = "sec_prison"
+	req_access = list(access_brig)
 
 /area/exodus/security/brig/solitaryB
 	name = "\improper Security - Solitary 2"
 	icon_state = "sec_prison"
+	req_access = list(access_brig)
 
 //Prison
 


### PR DESCRIPTION
## Description of changes
More tweaks and adjustments as a result of playtesting 

## Why and what will this PR improve
See above, but mostly does fixes to security access and additions to mining
Fixes #62

## Authorship
Woodrat

## Changelog
:cl:
add: Added a mining drill to the mining dock.
add: Added Long Range Holopads to shuttles and bridge.
bugfix: Replaced the engine setup SMES markers with SMES Main markers.
bugfix: Fixed detective's access to security.
bugfix: Fixed missing access requirements on armory emergency access.
/:cl: