### PR TITLE
Polaris Exodus Map Tweaks (Again)

### DIFF
--- a/maps/exodus/exodus-2.dmm
+++ b/maps/exodus/exodus-2.dmm
@@ -22097,6 +22097,7 @@
 "aUM" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/portables_connector,
+/obj/machinery/body_scan_display,
 /turf/floor/tiled/steel_grid,
 /area/exodus/medical/sleeper)
 "aUN" = (
@@ -29910,23 +29911,32 @@
 /turf/floor/plating,
 /area/exodus/maintenance/locker)
 "blw" = (
-/obj/machinery/space_heater,
-/obj/structure/sign/directions/pods{
+/obj/structure/handrail{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	id_tag = "mining_shuttle_pump_out_internal"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	cycle_to_external_air = 1;
+	id_tag = "mining_shuttle";
+	tag_interior_sensor = "mining_interior_sensor";
+	tag_pump_out_external = "mining_pump_out_external";
 	dir = 1;
-	pixel_y = 32
+	pixel_y = -25
 	},
-/turf/floor/tiled/steel_grid,
-/area/exodus/maintenance/atmos_control)
+/turf/floor/tiled/techfloor/grid,
+/area/ship/exodus_pod_mining)
 "blx" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/floor/tiled/steel_grid,
-/area/exodus/maintenance/atmos_control)
+/turf/floor/plating,
+/area/exodus/maintenance/cargo)
 "bly" = (
 /obj/machinery/vending/coffee,
 /turf/floor/wood/walnut,
@@ -32689,15 +32699,22 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/research/chargebay)
 "bra" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/structure/handrail{
+	dir = 1
 	},
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	id_tag = "mining_shuttle_pump_out_internal"
 	},
-/turf/floor/tiled/steel_grid,
-/area/exodus/maintenance/atmos_control)
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/obj/machinery/airlock_sensor{
+	id_tag = "mining_shuttle_sensor";
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/floor/tiled/techfloor/grid,
+/area/ship/exodus_pod_mining)
 "brb" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -33954,6 +33971,7 @@
 /obj/structure/table{
 	name = "plastic table frame"
 	},
+/obj/item/medical_lolli_jar,
 /turf/floor/tiled/steel_grid,
 /area/exodus/medical/reception)
 "btJ" = (
@@ -34074,13 +34092,18 @@
 /turf/floor/tiled/white,
 /area/exodus/medical/exam_room)
 "btV" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
+/obj/effect/floor_decal/corner/brown{
+	dir = 9
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/structure/rack{
+	dir = 1
 	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/item/clothing/mask/breath,
+/obj/item/rig/industrial/equipped,
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
 "btW" = (
@@ -34226,12 +34249,8 @@
 /turf/space,
 /area/space)
 "buo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/mining/drill,
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
 "bup" = (
@@ -36193,19 +36212,16 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/central_three)
 "byk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
-	},
-/turf/floor/tiled/steel_grid,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/floor/tiled/techfloor/grid,
 /area/exodus/maintenance/atmos_control)
 "byl" = (
 /obj/machinery/computer/modular/preset/medical,
@@ -38364,14 +38380,14 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/research/storage)
 "bCx" = (
-/obj/machinery/camera/network/civilian_west{
-	c_tag = "Cargo Mining Dock";
-	dir = 1
+/obj/structure/bed/chair/shuttle/black,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/alarm{
+	pixel_y = 22
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/ore_box,
-/turf/floor/tiled/steel_grid,
-/area/exodus/quartermaster/miningdock)
+/obj/machinery/atmospherics/pipe/manifold/hidden/red,
+/turf/floor/tiled/monotile,
+/area/ship/exodus_pod_mining)
 "bCy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
@@ -38404,9 +38420,6 @@
 	dir = 8;
 	name = "QM Office";
 	sort_type = "QM Office"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
@@ -38857,6 +38870,12 @@
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/storage/primary)
+"bDv" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/floor/tiled/steel_grid,
+/area/exodus/quartermaster/miningdock)
 "bDw" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -38960,10 +38979,11 @@
 /turf/floor/plating,
 /area/exodus/maintenance/research_port)
 "bDH" = (
-/obj/machinery/mining/brace,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/floor/tiled/steel_grid,
-/area/exodus/quartermaster/miningdock)
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 10
+	},
+/turf/wall/titanium,
+/area/ship/exodus_pod_mining)
 "bDI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -39065,7 +39085,10 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+	dir = 10
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
@@ -39206,10 +39229,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/turf/floor/plating,
+/turf/wall/prepainted,
 /area/exodus/maintenance/cargo)
 "bEf" = (
 /obj/machinery/conveyor{
@@ -39565,19 +39585,13 @@
 /turf/floor/tiled/white,
 /area/exodus/medical/medbay2)
 "bEU" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Mining Maintenance";
-	req_access = list("ACCESS_MINING");
-	autoset_access = 0
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden{
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/floor/tiled/techfloor/grid,
+/turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
 "bEV" = (
 /obj/structure/table,
@@ -39922,14 +39936,22 @@
 /turf/floor/plating,
 /area/exodus/medical/genetics)
 "bFE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
+/obj/machinery/oxygen_pump{
+	pixel_y = 32
 	},
-/turf/floor/plating,
-/area/exodus/maintenance/cargo)
+/obj/structure/handrail,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	id_tag = "mining_shuttle_pump";
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/turf/floor/tiled/techfloor/grid,
+/area/ship/exodus_pod_mining)
 "bFF" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/item/radio/intercom{
@@ -40007,11 +40029,13 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/storage)
 "bFO" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
+/obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
-/turf/floor/plating,
-/area/exodus/maintenance/cargo)
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/floor/tiled/techfloor/grid,
+/area/ship/exodus_pod_mining)
 "bFP" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -41544,9 +41568,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/sleeper{
-	dir = 4
-	},
+/obj/machinery/sleeper/standard,
 /turf/floor/tiled/steel_grid,
 /area/exodus/medical/cryo)
 "bID" = (
@@ -41760,15 +41782,20 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
 "bJa" = (
-/obj/item/folder/yellow,
-/obj/structure/table,
-/obj/item/pen,
-/obj/machinery/network/requests_console{
-	department = "Cargo Bay";
-	pixel_x = -32;
-	dir = 8
+/obj/machinery/conveyor{
+	backwards = 8;
+	dir = 9;
+	forwards = 2;
+	id_tag = "cargo_mining_conveyor";
+	movedir = 6
 	},
-/turf/floor/tiled/steel_grid,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/floor/plating,
 /area/exodus/quartermaster/miningdock)
 "bJb" = (
 /obj/effect/floor_decal/corner/brown{
@@ -42180,6 +42207,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/item/bodybag/rescue/loaded,
+/obj/item/bodybag/rescue/loaded,
+/obj/item/bodybag/rescue/loaded,
 /turf/floor/tiled/white,
 /area/exodus/medical/sleeper)
 "bJK" = (
@@ -42380,16 +42410,8 @@
 /turf/floor/plating,
 /area/exodus/medical/genetics)
 "bKg" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/floor/tiled/techfloor/grid,
+/obj/structure/grille,
+/turf/floor/plating,
 /area/exodus/maintenance/cargo)
 "bKh" = (
 /obj/structure/disposalpipe/segment,
@@ -42642,19 +42664,8 @@
 /turf/floor/plating,
 /area/exodus/quartermaster/miningdock)
 "bKI" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/brown{
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8;
-	icon_state = "warningcorner"
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/mining/brace,
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
 "bKK" = (
@@ -42968,9 +42979,6 @@
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/medical/medbay)
 "bLu" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -43158,13 +43166,11 @@
 /turf/floor/tiled/white,
 /area/exodus/research/xenobiology)
 "bLP" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/floor/tiled/steel_grid,
-/area/exodus/maintenance/atmos_control)
+/area/ship/exodus_pod_mining)
 "bLQ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -29;
@@ -43298,40 +43304,34 @@
 /turf/floor/plating,
 /area/exodus/engineering/sublevel_access)
 "bMg" = (
-/obj/effect/floor_decal/corner/brown{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
-/obj/structure/rack{
-	dir = 1
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/item/rig/industrial/equipped,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/ore_box,
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
 "bMh" = (
+/obj/structure/bed/chair/shuttle/black,
+/turf/floor/tiled/steel_grid,
+/area/ship/exodus_pod_mining)
+"bMi" = (
 /obj/machinery/material_processing/stacker{
 	input_turf = 1;
 	output_turf = 8
 	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
 /turf/floor/plating,
-/area/exodus/quartermaster/miningdock)
-"bMi" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
-/obj/abstract/landmark/start{
-	name = "Shaft Miner"
-	},
-/turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
 "bMj" = (
-/obj/effect/wallframe_spawn/reinforced,
-/turf/floor/plating,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
 "bMk" = (
 /obj/structure/disposalpipe/segment{
@@ -43357,9 +43357,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable/green{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
@@ -43519,6 +43521,8 @@
 	pixel_y = -30
 	},
 /obj/item/stack/tape_roll/barricade_tape/medical,
+/obj/item/auto_cpr,
+/obj/item/auto_cpr,
 /turf/floor/tiled/white,
 /area/exodus/medical/sleeper)
 "bMy" = (
@@ -43974,7 +43978,6 @@
 /turf/floor/plating,
 /area/exodus/research/xenobiology)
 "bNr" = (
-/obj/effect/paint_stripe/brown,
 /turf/wall/titanium,
 /area/ship/exodus_pod_mining)
 "bNs" = (
@@ -43995,6 +43998,9 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
@@ -44698,9 +44704,7 @@
 	pixel_x = 24
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/sleeper{
-	dir = 4
-	},
+/obj/machinery/sleeper/standard,
 /turf/floor/tiled/steel_grid,
 /area/exodus/medical/cryo)
 "bOU" = (
@@ -44910,7 +44914,7 @@
 	name = "Shaft Miner"
 	},
 /obj/structure/cable/green{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
@@ -47568,6 +47572,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
+/obj/random/plushie,
 /turf/floor/tiled/white,
 /area/exodus/medical/medbay4)
 "bUG" = (
@@ -47644,14 +47649,10 @@
 /obj/item/radio/intercom{
 	pixel_y = 20
 	},
-/obj/structure/hygiene/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
+/obj/machinery/washing_machine,
 /turf/floor/tiled/white,
 /area/exodus/medical/patient_wing)
 "bUQ" = (
@@ -47705,13 +47706,16 @@
 /turf/floor/tiled/white,
 /area/exodus/medical/medbay4)
 "bUW" = (
-/obj/item/chems/spray/cleaner,
 /obj/structure/table{
 	name = "plastic table frame"
 	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
+/obj/item/box/detergent,
+/obj/item/soap,
+/obj/item/roller/ironingboard,
+/obj/item/ironingiron,
 /turf/floor/tiled/white,
 /area/exodus/medical/patient_wing)
 "bUX" = (
@@ -49939,6 +49943,10 @@
 /turf/floor/tiled/white,
 /area/exodus/medical/patient_wing)
 "bZx" = (
+/obj/structure/table{
+	name = "plastic table frame"
+	},
+/obj/item/chems/spray/cleaner,
 /turf/floor/tiled/white,
 /area/exodus/medical/patient_wing)
 "bZy" = (
@@ -51449,12 +51457,19 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/maintenance/atmos_control)
 "ccC" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 29;
-	dir = 8
+/obj/machinery/space_heater,
+/obj/structure/sign/directions/pods{
+	dir = 1;
+	pixel_y = 32
 	},
-/turf/floor,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/floor/tiled/steel_grid,
 /area/exodus/maintenance/atmos_control)
 "ccD" = (
 /obj/random/obstruction,
@@ -51673,14 +51688,9 @@
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/engineering/break_room)
 "ccY" = (
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/structure/table/steel,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/turf/floor/tiled/steel_grid,
-/area/exodus/construction)
+/obj/machinery/oxygen_pump,
+/turf/wall/prepainted,
+/area/exodus/maintenance/atmos_control)
 "ccZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
@@ -51945,6 +51955,7 @@
 /obj/item/toolbox/emergency,
 /obj/item/flashlight,
 /obj/item/flashlight,
+/obj/item/auto_cpr,
 /turf/floor/tiled/white,
 /area/exodus/medical/biostorage)
 "cdx" = (
@@ -52403,12 +52414,18 @@
 /turf/floor/tiled/white,
 /area/exodus/medical/virology)
 "cep" = (
-/obj/random/tech_supply,
-/obj/structure/table/steel,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/turf/floor,
-/area/exodus/construction)
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8;
+	icon_state = "warningcorner"
+	},
+/turf/floor/tiled/steel_grid,
+/area/exodus/quartermaster/miningdock)
 "ceq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -52493,6 +52510,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
 	},
 /turf/floor,
 /area/exodus/maintenance/atmos_control)
@@ -52922,13 +52942,18 @@
 /turf/floor/plating,
 /area/exodus/maintenance/research_starboard)
 "cfx" = (
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/structure/table/steel,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/turf/floor/tiled/steel_grid,
-/area/exodus/construction)
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9
+	},
+/obj/machinery/door/airlock/external/bolted{
+	id_tag = "mining_shuttle_inner"
+	},
+/turf/floor/tiled/techfloor,
+/area/ship/exodus_pod_mining)
 "cfy" = (
 /obj/item/clothing/mask/smokable/cigarette,
 /turf/floor/airless,
@@ -54544,6 +54569,7 @@
 	pixel_x = -22;
 	dir = 4
 	},
+/obj/machinery/body_scan_display,
 /turf/floor/tiled/white,
 /area/exodus/medical/surgery)
 "ciS" = (
@@ -54635,6 +54661,7 @@
 	pixel_x = 22;
 	dir = 8
 	},
+/obj/machinery/body_scan_display,
 /turf/floor/tiled/white,
 /area/exodus/medical/surgery2)
 "cjf" = (
@@ -55159,9 +55186,7 @@
 /turf/floor/tiled/white,
 /area/exodus/medical/virology)
 "ckj" = (
-/obj/machinery/computer/operating{
-	dir = 8
-	},
+/obj/machinery/vitals_monitor,
 /turf/floor/tiled/white/monotile,
 /area/exodus/medical/surgery)
 "ckk" = (
@@ -55209,9 +55234,7 @@
 /turf/floor/tiled/white/monotile,
 /area/exodus/medical/surgery2)
 "ckq" = (
-/obj/machinery/computer/operating{
-	dir = 4
-	},
+/obj/machinery/vitals_monitor,
 /turf/floor/tiled/white/monotile,
 /area/exodus/medical/surgery2)
 "ckr" = (
@@ -55383,10 +55406,14 @@
 /turf/floor/tiled/white,
 /area/exodus/research/xenobiology/xenoflora)
 "ckM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/floor/plating,
-/area/exodus/maintenance/atmos_control)
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/floor/tiled/steel_grid,
+/area/ship/exodus_pod_mining)
 "ckN" = (
 /obj/machinery/network/requests_console{
 	department = "Science";
@@ -56648,9 +56675,17 @@
 /turf/floor/plating,
 /area/exodus/maintenance/starboardsolar)
 "cnp" = (
-/obj/machinery/oxygen_pump,
-/turf/wall/prepainted,
-/area/exodus/construction)
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/floor/tiled/techfloor/grid,
+/area/ship/exodus_pod_mining)
 "cnq" = (
 /obj/machinery/light{
 	dir = 8
@@ -63411,23 +63446,36 @@
 /turf/floor/plating,
 /area/ship/exodus_pod_research)
 "cUO" = (
-)
+/obj/machinery/computer/ship/helm{
+	dir = 1
+	},
+/obj/effect/overmap/visitable/ship/landable/pod/mining,
+/turf/floor/tiled/monotile,
+/area/ship/exodus_pod_mining)
 "cYR" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/central_two)
+"dar" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/floor/tiled/steel_grid,
+/area/exodus/maintenance/atmos_control)
 "dcK" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/turf/floor/plating,
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/emcloset,
+/turf/floor/tiled/monotile,
 /area/ship/exodus_pod_mining)
 "djd" = (
 /obj/structure/cable{
@@ -63440,11 +63488,9 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/starboard)
 "dkO" = (
-/obj/machinery/computer/shuttle_control/explore/mining,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/floor/tiled/steel_grid,
+/obj/effect/paint/red,
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
+/turf/wall/titanium,
 /area/ship/exodus_pod_mining)
 "dmw" = (
 /obj/machinery/power/apc/critical{
@@ -63580,20 +63626,17 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/engineering/foyer)
 "dRD" = (
-/obj/effect/overmap/visitable/ship/landable/pod/mining,
-/obj/machinery/computer/ship/helm,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/effect/paint/red,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
-/turf/floor/tiled/steel_grid,
+/turf/wall/titanium,
 /area/ship/exodus_pod_mining)
 "egZ" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 10
 	},
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/floor,
+/turf/wall/titanium,
 /area/ship/exodus_pod_mining)
 "ejv" = (
 /obj/effect/shuttle_landmark/research_pod_dock,
@@ -63616,6 +63659,12 @@
 	},
 /turf/floor/tiled/techfloor/grid,
 /area/ship/exodus_pod_research)
+"ejT" = (
+/obj/machinery/computer/ship/engines{
+	dir = 4
+	},
+/turf/floor/tiled/monotile,
+/area/ship/exodus_pod_mining)
 "elq" = (
 /obj/machinery/hologram/holopad{
 	holopad_id = "Security North"
@@ -63623,12 +63672,8 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/security/main)
 "eqn" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	dir = 10
-	},
-/turf/floor/plating,
+/obj/machinery/atmospherics/unary/engine,
+/turf/floor/airless,
 /area/ship/exodus_pod_mining)
 "esY" = (
 /obj/effect/paint_stripe/blue,
@@ -63716,18 +63761,24 @@
 /turf/floor/tiled/dark,
 /area/ship/exodus_pod_engineering)
 "fhb" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/window/reinforced{
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/button/alternate/door/bolts{
+	id_tag = "mhatch";
+	name = "Rear Hatch Release";
+	pixel_x = -24;
+	req_access = list("ACCESS_MINING")
 	},
-/obj/machinery/network/relay/long_range,
-/turf/floor/tiled/steel_grid,
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Rear Hatch";
+	id_tag = "mhatch";
+	autoset_access = 0;
+	stock_part_presets = list(/decl/stock_part_preset/radio/receiver/airlock = 1, /decl/stock_part_preset/radio/event_transmitter/airlock = 1)
+	},
+/turf/floor/tiled/techfloor,
 /area/ship/exodus_pod_mining)
 "fmR" = (
 /obj/machinery/door/airlock/external/bolted{
@@ -63782,17 +63833,16 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/central_three)
 "fMw" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/effect/floor_decal/industrial/warning{
 	dir = 8;
-	level = 2
+	icon_state = "warning"
 	},
-/turf/floor/tiled/steel_grid,
+/obj/structure/handrail,
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/hidden/blue{
+	dir = 10
+	},
+/turf/floor/tiled/techmaint,
 /area/ship/exodus_pod_mining)
 "fPv" = (
 /obj/effect/floor_decal/corner/brown{
@@ -63818,6 +63868,12 @@
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /mob/living/exosuit/premade/light/exploration,
+/turf/floor/tiled/steel_grid,
+/area/exodus/quartermaster/miningdock)
+"fUi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
 "gcu" = (
@@ -63887,6 +63943,17 @@
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/central_two)
+"gJa" = (
+/obj/structure/bed/chair/shuttle/black,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_y = 32
+	},
+/turf/floor/tiled/monotile,
+/area/ship/exodus_pod_mining)
 "gOE" = (
 /obj/structure/bed/chair/shuttle/black{
 	dir = 8
@@ -63913,6 +63980,12 @@
 /obj/effect/floor_decal/industrial/warning/full,
 /turf/floor/plating,
 /area/ship/exodus_pod_research)
+"hbj" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/floor/tiled/techmaint,
+/area/ship/exodus_pod_mining)
 "hbt" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -63944,13 +64017,17 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/storage)
 "hmY" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/machinery/door/airlock/maintenance{
+	name = "Mining Maintenance";
+	req_access = list("ACCESS_MINING");
+	autoset_access = 0
 	},
-/obj/machinery/door/airlock/hatch,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
 /turf/floor/tiled/techfloor/grid,
-/area/ship/exodus_pod_mining)
+/area/exodus/maintenance/cargo)
 "hoh" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -64035,16 +64112,32 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/starboard)
 "hWZ" = (
-/obj/structure/bed/chair,
-/obj/machinery/light{
+/obj/effect/floor_decal/steeldecal/steel_decals5,
+/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	level = 2;
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 4
 	},
 /turf/floor/tiled/steel_grid,
 /area/ship/exodus_pod_mining)
+"hYG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/mining/brace,
+/turf/floor/tiled/steel_grid,
+/area/exodus/quartermaster/miningdock)
 "hZw" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -64058,17 +64151,23 @@
 /turf/floor/tiled/techfloor/grid,
 /area/ship/exodus_pod_research)
 "idh" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/blue,
+/turf/floor/tiled/techmaint,
+/area/ship/exodus_pod_mining)
+"idY" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/obj/structure/bed/chair/shuttle/black,
+/obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 4
 	},
-/obj/machinery/hologram/holopad/longrange,
-/turf/floor/tiled/steel_grid,
-/area/ship/exodus_pod_mining)
-"idY" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable/green,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/floor/tiled/steel_grid,
+/turf/floor/tiled/monotile,
 /area/ship/exodus_pod_mining)
 "igB" = (
 /obj/machinery/hologram/holopad,
@@ -64104,6 +64203,23 @@
 /obj/effect/paint/red,
 /turf/wall/titanium,
 /area/shuttle/arrival/station)
+"iue" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/airlock/external/bolted{
+	id_tag = "mining_shuttle_outer"
+	},
+/obj/machinery/button/access/exterior{
+	dir = 4;
+	id_tag = "mining_shuttle";
+	pixel_x = 16;
+	pixel_y = -26;
+	directional_offset = null
+	},
+/turf/floor/tiled/techfloor,
+/area/ship/exodus_pod_mining)
 "ixD" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
@@ -64128,11 +64244,12 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/bridge)
 "iKS" = (
-/obj/machinery/conveyor{
-	id_tag = "cargo_mining_conveyor"
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 5
 	},
-/turf/floor/plating,
-/area/exodus/quartermaster/miningdock)
+/obj/effect/floor_decal/industrial/warning/full,
+/turf/floor/tiled/techmaint,
+/area/ship/exodus_pod_mining)
 "iNs" = (
 /obj/effect/floor_decal/corner/white{
 	dir = 10
@@ -64145,14 +64262,23 @@
 	},
 /turf/floor/tiled/dark/monotile,
 /area/shuttle/arrival/station)
-"iTt" = (
-/obj/structure/bed/chair{
+"iRq" = (
+/obj/structure/bed/chair/shuttle/black,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 9
 	},
-/turf/floor/tiled/steel_grid,
+/turf/floor/tiled/monotile,
+/area/ship/exodus_pod_mining)
+"iTt" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/structure/handrail,
+/turf/floor/tiled/techmaint,
 /area/ship/exodus_pod_mining)
 "iUa" = (
 /obj/effect/floor_decal/corner/brown/diagonal{
@@ -64174,6 +64300,11 @@
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/starboard)
+"jfm" = (
+/obj/effect/floor_decal/rust/steel_decals_rusted2,
+/obj/structure/bed/chair/shuttle/black,
+/turf/floor/tiled/steel_grid,
+/area/ship/exodus_pod_mining)
 "jfD" = (
 /obj/abstract/landmark/start{
 	name = "Shaft Miner"
@@ -64188,16 +64319,13 @@
 /turf/floor/plating,
 /area/exodus/engineering/storage)
 "jsn" = (
-/obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = -22
+/obj/machinery/conveyor{
+	id_tag = "cargo_mining_conveyor"
 	},
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/floor/tiled/steel_grid,
+/turf/floor/plating,
 /area/exodus/quartermaster/miningdock)
 "jva" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -64206,6 +64334,21 @@
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/secondary/exit)
+"jxl" = (
+/obj/machinery/power/smes/buildable{
+	RCon_tag = "Engine - Main";
+	charge = 1e+007;
+	input_attempt = 1;
+	input_level = 1e+006;
+	output_attempt = 1;
+	output_level = 1e+006
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
+	},
+/obj/effect/floor_decal/industrial/warning/full,
+/turf/floor/plating,
+/area/ship/exodus_pod_mining)
 "jFq" = (
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
@@ -64238,12 +64381,20 @@
 /turf/floor/tiled/white,
 /area/exodus/research/robotics)
 "keS" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 4;
-	id_tag = "mining_pump_out_external"
+/obj/machinery/computer/shuttle_control/explore/mining{
+	dir = 1
 	},
-/turf/floor,
+/turf/floor/tiled/monotile,
 /area/ship/exodus_pod_mining)
+"kkU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/abstract/landmark/start{
+	name = "Shaft Miner"
+	},
+/turf/floor/tiled/steel_grid,
+/area/exodus/quartermaster/miningdock)
 "klA" = (
 /turf/floor/plating,
 /area/space)
@@ -64264,6 +64415,26 @@
 	},
 /turf/floor/tiled/white,
 /area/ship/exodus_pod_research)
+"ktz" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 9
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/rack{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/clothing/mask/breath,
+/obj/item/rig/industrial/equipped,
+/turf/floor/tiled/steel_grid,
+/area/exodus/quartermaster/miningdock)
 "kvT" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -64279,6 +64450,23 @@
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/secondary/exit)
+"kDf" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/oxygen_pump{
+	pixel_y = 32
+	},
+/obj/structure/handrail,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	id_tag = "mining_shuttle_pump";
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/turf/floor/tiled/techfloor/grid,
+/area/ship/exodus_pod_mining)
 "kSt" = (
 /obj/machinery/vending/coffee{
 	dir = 1
@@ -64300,6 +64488,11 @@
 /obj/item/chems/dropper,
 /turf/floor/tiled/white,
 /area/exodus/medical/chemistry)
+"leK" = (
+/obj/effect/floor_decal/rust/steel_decals_rusted1,
+/obj/structure/bed/chair/shuttle/black,
+/turf/floor/tiled/steel_grid,
+/area/ship/exodus_pod_mining)
 "lfJ" = (
 /obj/item/radio/beacon,
 /obj/effect/floor_decal/corner/white{
@@ -64345,11 +64538,10 @@
 /turf/floor/tiled/dark/monotile,
 /area/shuttle/arrival/station)
 "lDV" = (
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/manifold/hidden/red{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
 	},
-/turf/floor/tiled/steel_grid,
+/turf/floor/tiled/techmaint,
 /area/ship/exodus_pod_mining)
 "lFM" = (
 /obj/machinery/power/apc{
@@ -64380,18 +64572,28 @@
 /turf/floor/tiled/white,
 /area/ship/exodus_pod_research)
 "lHF" = (
-/obj/machinery/light,
-/obj/machinery/mining/drill,
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/shipsensors/weak,
+/obj/effect/floor_decal/industrial/warning/full,
+/turf/floor/airless,
+/area/ship/exodus_pod_mining)
+"lKF" = (
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
 "miB" = (
-/obj/structure/cable/green,
-/obj/machinery/ion_thruster{
-	dir = 1;
-	icon_state = "nozzle"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/floor,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/floor/tiled/steel_grid,
 /area/ship/exodus_pod_mining)
 "mue" = (
 /turf/floor/tiled/techfloor/grid,
@@ -64401,6 +64603,13 @@
 /obj/machinery/door/firedoor,
 /turf/floor/plating,
 /area/exodus/bridge)
+"mFy" = (
+/obj/structure/table/steel,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/turf/floor/tiled/steel_grid,
+/area/exodus/construction)
 "mGD" = (
 /obj/machinery/fabricator/industrial{
 	id_tag = "science"
@@ -64465,6 +64674,23 @@
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/secondary/exit)
+"ncf" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock{
+	start_pressure = 730
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/floor/tiled/techfloor/grid,
+/area/ship/exodus_pod_mining)
 "ngU" = (
 /obj/effect/shuttle_landmark/exodus_main_aft,
 /turf/space,
@@ -64519,6 +64745,13 @@
 	},
 /turf/floor/plating,
 /area/exodus/engineering/storage)
+"nWl" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8;
+	level = 2
+	},
+/turf/floor/tiled/steel_grid,
+/area/ship/exodus_pod_mining)
 "nYi" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -64531,14 +64764,8 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/central_two)
 "nZs" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/floor,
+/obj/machinery/atmospherics/pipe/simple/hidden/red,
+/turf/wall/titanium,
 /area/ship/exodus_pod_mining)
 "oaC" = (
 /obj/effect/floor_decal/corner/paleblue{
@@ -64566,6 +64793,13 @@
 	},
 /turf/floor/plating,
 /area/exodus/engineering/storage)
+"okm" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/network/relay/long_range,
+/turf/floor/tiled/monotile,
+/area/ship/exodus_pod_mining)
 "ouk" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -64573,31 +64807,21 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/central_three)
 "oxE" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 5
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning"
 	},
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/floor/tiled/steel_grid,
+/obj/machinery/meter,
+/turf/floor/tiled/techmaint,
 /area/ship/exodus_pod_mining)
 "oxF" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/manifold/hidden/red{
+	dir = 4
 	},
-/obj/structure/catwalk,
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/handrail{
-	dir = 8
-	},
-/turf/floor,
+/turf/wall/titanium,
 /area/ship/exodus_pod_mining)
 "oAO" = (
 /obj/structure/table/reinforced,
@@ -64606,6 +64830,20 @@
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/engineering/engine_monitoring)
+"oBL" = (
+/obj/machinery/camera/network/civilian_west{
+	c_tag = "Cargo Mining Dock";
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/folder/yellow,
+/obj/item/pen,
+/obj/item/radio/intercom{
+	dir = 1;
+	pixel_y = -30
+	},
+/turf/floor/tiled/steel_grid,
+/area/exodus/quartermaster/miningdock)
 "oDi" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -64644,6 +64882,12 @@
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/central_two)
+"phI" = (
+/obj/effect/floor_decal/industrial/loading{
+	dir = 4
+	},
+/turf/floor/tiled/steel_grid,
+/area/exodus/quartermaster/miningdock)
 "pnI" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
@@ -64685,24 +64929,16 @@
 /turf/floor/plating,
 /area/ship/exodus_pod_research)
 "pGo" = (
-/obj/effect/floor_decal/corner/brown{
-	dir = 9
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
 	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light{
-	dir = 8
+	dir = 4
 	},
-/obj/structure/rack{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/item/rig/industrial/equipped,
-/turf/floor/tiled/steel_grid,
-/area/exodus/quartermaster/miningdock)
+/turf/floor/tiled/techfloor/grid,
+/area/ship/exodus_pod_mining)
 "pWa" = (
 /obj/effect/shuttle_landmark/exodus_main_fore,
 /turf/space,
@@ -64719,18 +64955,37 @@
 	},
 /turf/floor/tiled/steel_grid,
 /area/ship/exodus_pod_research)
-"qkc" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
+"pWN" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 9
 	},
-/obj/machinery/atmospherics/unary/tank/air{
+/obj/structure/rack{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/warning/cee{
-	dir = 8;
-	icon_state = "warningcee"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/floor/plating,
+/obj/item/clothing/mask/breath,
+/obj/item/rig/industrial/equipped,
+/turf/floor/tiled/steel_grid,
+/area/exodus/quartermaster/miningdock)
+"qfO" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	dir = 4;
+	id_tag = "mining_pump_out_external"
+	},
+/obj/structure/grille,
+/turf/floor/airless,
+/area/ship/exodus_pod_mining)
+"qkc" = (
+/obj/structure/handrail{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/floor/tiled/steel_grid,
 /area/ship/exodus_pod_mining)
 "qlX" = (
 /obj/machinery/hologram/holopad,
@@ -64742,6 +64997,11 @@
 	},
 /turf/floor/tiled/dark/monotile,
 /area/shuttle/arrival/station)
+"qra" = (
+/obj/machinery/sleeper/standard,
+/obj/effect/floor_decal/industrial/outline,
+/turf/floor/tiled/monotile,
+/area/ship/exodus_pod_mining)
 "qvM" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -64753,16 +65013,14 @@
 /turf/floor/plating,
 /area/ship/exodus_pod_research)
 "qBY" = (
-/obj/structure/cable/green{
+/obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/external/bolted{
-	id_tag = "mining_shuttle_inner"
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
-	dir = 8
-	},
-/turf/floor/tiled/techfloor/grid,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/floor/tiled/techmaint,
 /area/ship/exodus_pod_mining)
 "qHi" = (
 /obj/machinery/light{
@@ -64818,6 +65076,17 @@
 	},
 /turf/floor/tiled/steel_grid,
 /area/ship/exodus_pod_research)
+"rgy" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/floor/tiled/steel_grid,
+/area/exodus/maintenance/atmos_control)
 "rhM" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
@@ -64825,18 +65094,11 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/secondary/entry/starboard)
 "rjP" = (
-/obj/structure/catwalk,
-/obj/item/radio/beacon,
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/effect/paint/red,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/floor,
+/turf/wall/titanium,
 /area/ship/exodus_pod_mining)
 "rkN" = (
 /obj/effect/floor_decal/corner/lime{
@@ -64862,15 +65124,9 @@
 /turf/floor/plating,
 /area/exodus/maintenance/research_starboard)
 "rup" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/turf/floor/plating,
+/obj/machinery/recharge_station,
+/obj/effect/floor_decal/industrial/outline,
+/turf/floor/tiled/monotile,
 /area/ship/exodus_pod_mining)
 "rwB" = (
 /obj/structure/cable/cyan{
@@ -64879,6 +65135,14 @@
 /obj/machinery/light,
 /turf/floor/bluegrid,
 /area/exodus/turret_protected/ai_upload)
+"rAu" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/turf/floor/tiled/steel_grid,
+/area/exodus/quartermaster/miningdock)
 "rNu" = (
 /obj/structure/table{
 	name = "plastic table frame"
@@ -64889,10 +65153,31 @@
 /turf/floor/tiled/dark/monotile,
 /area/shuttle/arrival/station)
 "rPP" = (
-/obj/machinery/computer/ship/engines{
-	dir = 1
+/obj/machinery/hologram/holopad/longrange,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/effect/floor_decal/steeldecal/steel_decals3{
+	dir = 6
 	},
-/turf/floor/tiled/steel_grid,
+/obj/effect/floor_decal/steeldecal/steel_decals3{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals3{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals3,
+/obj/effect/floor_decal/steeldecal/steel_decals3{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/floor/tiled/monotile,
 /area/ship/exodus_pod_mining)
 "rQB" = (
 /obj/effect/paint_stripe/yellow,
@@ -64907,18 +65192,25 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/secondary/entry/port)
 "rVT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/bed/chair/shuttle/black,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 4
 	},
-/turf/floor/tiled/steel_grid,
+/turf/floor/tiled/monotile,
 /area/ship/exodus_pod_mining)
 "rXI" = (
-/obj/machinery/shipsensors/weak,
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
-/turf/floor,
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/floor/tiled/monotile,
 /area/ship/exodus_pod_mining)
 "rYD" = (
 /obj/structure/cable/green{
@@ -64941,20 +65233,11 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/port)
 "sdB" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/atmospherics/unary/tank/air{
+	dir = 4
 	},
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/red,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/floor/tiled/steel_grid,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/floor/tiled/techfloor/grid,
 /area/ship/exodus_pod_mining)
 "sfM" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -64971,25 +65254,23 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/central_two)
 "sgI" = (
-/obj/machinery/conveyor{
-	backwards = 8;
-	dir = 9;
-	forwards = 2;
-	id_tag = "cargo_mining_conveyor";
-	movedir = 6
+/obj/machinery/network/requests_console{
+	department = "Cargo Bay";
+	pixel_x = -32;
+	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/floor/plating,
+/turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
 "sjj" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	icon_state = "2-4"
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 8
 	},
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/turf/floor/plating,
+/obj/effect/floor_decal/corner_techfloor_grid,
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/handrail{
+	dir = 8
+	},
+/turf/floor/airless,
 /area/ship/exodus_pod_mining)
 "ssg" = (
 /turf/floor/tiled/techfloor,
@@ -65005,21 +65286,15 @@
 /turf/floor/tiled/white,
 /area/ship/exodus_pod_research)
 "syF" = (
-/obj/structure/cable/green{
-	icon_state = "0-2"
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
 	},
-/obj/structure/cable/green,
-/obj/structure/catwalk,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/floor,
+/turf/floor/tiled/techfloor/grid,
 /area/ship/exodus_pod_mining)
 "sBp" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -65045,16 +65320,15 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/central_two)
 "sFN" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
+/obj/structure/bed/chair/shuttle/black,
+/obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/light{
-	dir = 8
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 5
 	},
-/turf/floor/tiled/steel_grid,
+/turf/floor/tiled/monotile,
 /area/ship/exodus_pod_mining)
 "sFU" = (
 /obj/effect/floor_decal/corner/brown/diagonal{
@@ -65082,6 +65356,12 @@
 	},
 /turf/floor/tiled/dark/monotile,
 /area/shuttle/arrival/station)
+"sPP" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 1
+	},
+/turf/wall/titanium,
+/area/ship/exodus_pod_mining)
 "sVy" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
@@ -65107,6 +65387,13 @@
 	},
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/engineering)
+"thZ" = (
+/obj/structure/table/steel,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/turf/floor,
+/area/exodus/construction)
 "tos" = (
 /obj/effect/floor_decal/corner/purple{
 	dir = 1
@@ -65114,18 +65401,9 @@
 /turf/floor/tiled/white,
 /area/exodus/research)
 "tpe" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/floor/plating,
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/floor/tiled/monotile,
 /area/ship/exodus_pod_mining)
 "tsZ" = (
 /obj/effect/floor_decal/spline/plain,
@@ -65148,18 +65426,10 @@
 /turf/floor/pool,
 /area/exodus/crew_quarters/fitness)
 "tzU" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/air/airlock{
-	start_pressure = 730
-	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	icon_state = "warning"
-	},
-/turf/floor/plating,
+/turf/floor/tiled/steel_grid,
 /area/ship/exodus_pod_mining)
 "tAY" = (
 /obj/effect/floor_decal/corner/purple/full,
@@ -65222,39 +65492,33 @@
 /turf/wall/titanium,
 /area/ship/exodus_pod_research)
 "tUa" = (
-/obj/effect/shuttle_landmark/mining_pod_dock,
 /obj/structure/cable/green{
-	icon_state = "2-4"
+	icon_state = "0-4"
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/power/terminal{
+	dir = 8
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	id_tag = "mining_shuttle_pump_out_internal";
-	dir = 1
-	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	cycle_to_external_air = 1;
-	id_tag = "mining_shuttle";
-	tag_interior_sensor = "mining_interior_sensor";
-	tag_pump_out_external = "mining_pump_out_external";
-	pixel_x = -25;
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/floor/tiled/techfloor/grid,
+/turf/floor/tiled/techmaint,
 /area/ship/exodus_pod_mining)
 "tXh" = (
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/airlock_sensor{
+	dir = 8;
+	id_tag = "mining_interior_sensor";
+	pixel_x = 22
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	id_tag = "mining_shuttle_pump_out_internal";
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
-/turf/floor/tiled/techfloor/grid,
+/turf/floor/tiled/techmaint,
 /area/ship/exodus_pod_mining)
 "tYK" = (
 /obj/effect/floor_decal/corner_steel_grid{
@@ -65263,20 +65527,10 @@
 /turf/floor/tiled/dark/monotile,
 /area/shuttle/arrival/station)
 "ult" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 6
 	},
-/obj/machinery/door/airlock/external/bolted{
-	id_tag = "mining_shuttle_outer"
-	},
-/obj/machinery/button/access/exterior{
-	dir = 4;
-	id_tag = "mining_shuttle";
-	pixel_x = 16;
-	pixel_y = -26;
-	directional_offset = null
-	},
-/turf/floor/tiled/techfloor/grid,
+/turf/wall/titanium,
 /area/ship/exodus_pod_mining)
 "uoa" = (
 /obj/machinery/door/airlock/external/bolted{
@@ -65330,12 +65584,10 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/engineering/foyer)
 "uRH" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/turf/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/radio/beacon,
+/turf/floor/tiled/steel_grid,
 /area/ship/exodus_pod_mining)
 "vcu" = (
 /obj/effect/floor_decal/corner/lime{
@@ -65368,18 +65620,19 @@
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/engineering)
+"vnz" = (
+/obj/machinery/computer/ship/sensors{
+	dir = 1
+	},
+/turf/floor/tiled/monotile,
+/area/ship/exodus_pod_mining)
 "vAy" = (
-/obj/structure/cable/green{
+/obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/floor,
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/turf/floor/plating,
 /area/ship/exodus_pod_mining)
 "vHf" = (
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -65401,24 +65654,33 @@
 	},
 /turf/floor/plating,
 /area/space)
+"vKB" = (
+/obj/effect/floor_decal/rust/mono_rusted1,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/door/window/northleft{
+	name = "Cockpit"
+	},
+/turf/floor/tiled/steel_grid,
+/area/ship/exodus_pod_mining)
 "vPY" = (
 /obj/structure/table/reinforced,
 /obj/item/gps,
 /turf/floor/tiled/steel_grid,
 /area/exodus/engineering/engineering_monitoring)
 "vRS" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	id_tag = "mining_shuttle_pump"
-	},
-/obj/machinery/airlock_sensor{
-	id_tag = "mining_shuttle_sensor";
-	pixel_x = -25;
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/turf/floor/tiled/techfloor/grid,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/floor/tiled/techmaint,
 /area/ship/exodus_pod_mining)
 "vSZ" = (
 /obj/structure/cable/green{
@@ -65441,26 +65703,31 @@
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/maintenance/locker)
 "whh" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
-/turf/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/effect/shuttle_landmark/mining_pod_dock,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/turf/floor/tiled/techmaint,
 /area/ship/exodus_pod_mining)
 "wht" = (
-/obj/structure/catwalk,
-/obj/machinery/button/access/interior{
-	id_tag = "mining_shuttle";
-	pixel_x = -5;
-	pixel_y = 25
+/obj/effect/floor_decal/rust/mono_rusted3,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/glass{
+	name = "Passenger Compartment"
 	},
-/obj/machinery/airlock_sensor{
-	dir = 8;
-	id_tag = "mining_interior_sensor";
-	pixel_x = 22
-	},
-/turf/floor,
+/turf/floor/tiled/steel_grid,
 /area/ship/exodus_pod_mining)
 "wiC" = (
 /obj/item/stack/material/ore/silver,
@@ -65487,31 +65754,20 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/port)
 "wlW" = (
-/obj/machinery/computer/ship/sensors,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/effect/paint/red,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 5
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/red,
-/turf/floor/tiled/steel_grid,
+/turf/wall/titanium,
 /area/ship/exodus_pod_mining)
 "wnS" = (
-/obj/structure/window/reinforced,
-/obj/structure/table{
-	name = "plastic table frame"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/machinery/recharger,
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 25
-	},
-/turf/floor/tiled/steel_grid,
+/turf/floor/tiled/techmaint,
 /area/ship/exodus_pod_mining)
 "woj" = (
 /obj/machinery/hologram/holopad{
@@ -65560,6 +65816,26 @@
 /obj/structure/table,
 /turf/floor/tiled/white,
 /area/exodus/research/robotics)
+"wNW" = (
+/obj/structure/handrail{
+	dir = 8
+	},
+/turf/floor/tiled/steel_grid,
+/area/ship/exodus_pod_mining)
+"wQd" = (
+/obj/machinery/atmospherics/binary/pump/on{
+	dir = 8;
+	target_pressure = 315
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/structure/sign/warning/airlock{
+	pixel_y = 32
+	},
+/obj/structure/handrail,
+/turf/floor/tiled/techmaint,
+/area/ship/exodus_pod_mining)
 "wTp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -65575,6 +65851,21 @@
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/central_two)
+"xfi" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 1
+	},
+/obj/machinery/meter,
+/obj/structure/fuel_port{
+	dir = 1;
+	pixel_y = -32
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/handrail,
+/turf/floor/tiled/techmaint,
+/area/ship/exodus_pod_mining)
 "xhz" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
@@ -65595,11 +65886,37 @@
 "xrP" = (
 /turf/floor/wood/walnut,
 /area/exodus/engineering/break_room)
-"xCt" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	id_tag = "mining_shuttle_pump"
+"xva" = (
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/floor/tiled/techfloor/grid,
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/floor/tiled/monotile,
+/area/ship/exodus_pod_mining)
+"xCt" = (
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/button/access/interior{
+	id_tag = "mining_shuttle";
+	pixel_x = 16;
+	pixel_y = 26;
+	dir = 8
+	},
+/turf/floor/tiled/techmaint,
 /area/ship/exodus_pod_mining)
 "xFu" = (
 /obj/effect/floor_decal/corner/lime{
@@ -65623,19 +65940,10 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/research/docking)
 "xJn" = (
-/obj/machinery/power/smes/buildable{
-	RCon_tag = "Engine - Main";
-	charge = 1e+007;
-	input_attempt = 1;
-	input_level = 1e+006;
-	output_attempt = 1;
-	output_level = 1e+006
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/warning/full,
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/turf/floor/plating,
+/turf/floor/tiled/steel_grid,
 /area/ship/exodus_pod_mining)
 "xOe" = (
 /obj/machinery/door/firedoor,
@@ -75885,7 +76193,7 @@ cLU
 cLU
 cLU
 cLU
-cLU
+bNB
 cLU
 cLU
 cLU
@@ -76142,7 +76450,7 @@ cLU
 cLU
 cLU
 cLU
-cLU
+bNB
 cLU
 cLU
 cLU
@@ -76399,7 +76707,7 @@ cLU
 cLU
 cLU
 cLU
-cLU
+bNB
 cLU
 cLU
 cLU
@@ -76656,7 +76964,7 @@ cLU
 cLU
 cLU
 cLU
-cLU
+bNB
 cLU
 cLU
 cLU
@@ -76913,7 +77221,7 @@ cLU
 cLU
 cLU
 cLU
-cLU
+bNB
 cLU
 cLU
 cLU
@@ -77170,7 +77478,7 @@ cLU
 cLU
 cLU
 cLU
-cLU
+bNB
 cLU
 cLU
 cLU
@@ -77427,7 +77735,7 @@ cLU
 cLU
 cLU
 cLU
-cLU
+bNB
 cLU
 cLU
 cLU
@@ -77684,7 +77992,7 @@ cLU
 cLU
 cLU
 cLU
-cLU
+bNB
 cLU
 cLU
 cLU
@@ -77941,7 +78249,7 @@ cLU
 cLU
 cLU
 cLU
-cLU
+bNB
 cLU
 cLU
 cLU
@@ -78198,9 +78506,9 @@ cLU
 cLU
 cLU
 cLU
-cLU
-cLU
-cLU
+bNB
+bNB
+bNB
 cLU
 cLU
 cLU
@@ -83061,6 +83369,8 @@ cLU
 cLU
 cLU
 cLU
+cLU
+cLU
 bqY
 apc
 aQh
@@ -83076,8 +83386,6 @@ aQh
 aQh
 apc
 aGX
-cLU
-aaf
 cLU
 cLU
 cLU
@@ -83318,19 +83626,19 @@ aRB
 aRF
 aLF
 cLU
-aQh
-aQh
-aQh
-aQh
-aQh
-aQh
-aQh
-aQh
-aQh
-aQh
-aQh
-apc
-aGX
+cLU
+cLU
+cLU
+cLU
+cLU
+cLU
+cLU
+cLU
+cLU
+cLU
+cLU
+cLU
+cLU
 cLU
 cLU
 cLU
@@ -83428,8 +83736,8 @@ cLU
 cLU
 cLU
 cLU
-cUO
-cUO
+cLU
+cLU
 "}
 (70,1,1) = {"
 cLU
@@ -83575,23 +83883,23 @@ bCE
 bEf
 aLF
 cLU
-keS
-fKm
-bNr
-bNr
-bNr
-tGo
-bNr
-tGo
-bNr
-bNr
-bNr
 noV
+noV
+bNr
+bNr
+bNr
+qfO
+qfO
+bNr
+tGo
+bNr
+bNr
+bNr
+cLU
+cLU
+cLU
 cLU
 aQh
-cLU
-cLU
-aaf
 cLU
 cLU
 cLU
@@ -83836,19 +84144,19 @@ eqn
 wlW
 sdB
 syF
-hmY
+bNr
 egZ
 oxF
 nZs
 sFN
 qkc
 rup
-miB
+bNr
+tGo
+bNr
+cLU
 cLU
 aQh
-aaf
-aaf
-aaf
 aaf
 aaf
 aam
@@ -84089,23 +84397,23 @@ bwb
 bEh
 bdP
 cLU
-fKm
+eqn
 dkO
 fMw
 idh
-tGo
-fKm
+jxl
+ncf
+cnp
 bNr
-rjP
 rVT
 tzU
 dcK
-miB
+okm
+ejT
+bNr
+bNr
 cLU
 aQh
-cLU
-cLU
-cLU
 aaf
 cLU
 aam
@@ -84346,7 +84654,7 @@ bCG
 bDL
 bdP
 cLU
-fKm
+noV
 dRD
 iTt
 lDV
@@ -84358,11 +84666,11 @@ idY
 xJn
 tpe
 miB
+jfm
+vnz
+tGo
 cLU
 aQh
-cLU
-cLU
-cLU
 aaf
 aam
 cLU
@@ -84614,13 +84922,13 @@ wht
 hWZ
 rPP
 uRH
-miB
+vKB
+bMh
+cUO
+tGo
 cLU
 aQh
-cLU
-cLU
-cLU
-aam
+aaf
 cLU
 cLU
 aaf
@@ -84860,24 +85168,24 @@ bvU
 bEi
 aLF
 cLU
-rXI
+noV
+dRD
+wQd
+hbj
+ult
+cfx
 fKm
 bNr
-bNr
-ult
+gJa
+bLP
+tpe
+ckM
+leK
+keS
 tGo
-bNr
-tGo
-bNr
-bNr
-bNr
-noV
 cLU
 aQh
-cLU
-cLU
-cLU
-aam
+aaf
 cLU
 cLU
 cLU
@@ -85117,24 +85425,24 @@ bvU
 bEi
 aLF
 cLU
-cLU
-cLU
-aSC
-aSC
-uoa
-aSC
-aSC
-uJB
-cLU
-cLU
-cLU
-cLU
+eqn
+dkO
+xfi
+iKS
+sPP
+bFE
+blw
+nZs
+bCx
+nWl
+tpe
+xva
+rXI
+bNr
+bNr
 cLU
 aQh
-cLU
-cLU
-cLU
-cbO
+aaf
 cLU
 cLU
 cLU
@@ -85374,24 +85682,24 @@ bvU
 bEi
 aLF
 cLU
-cLU
-cLU
-aSC
-bNg
-hbt
-wiC
-aSC
-aaf
-aaf
-cLU
-cLU
+eqn
+rjP
+bFO
+pGo
+bDH
+kDf
+bra
+nZs
+iRq
+wNW
+qra
+bNr
+tGo
+bNr
 cLU
 cLU
 aQh
-cLU
-cLU
-cLU
-aam
+aaf
 cLU
 cLU
 cLU
@@ -85631,24 +85939,24 @@ bCG
 bEi
 aLF
 cLU
-cLU
-cLU
-aSC
-bMs
-gny
-wAA
-aSC
-cLU
-aaf
-cLU
+noV
+noV
+bNr
+bNr
+bNr
+iue
+bNr
+bNr
+tGo
+bNr
+bNr
+bNr
+lHF
 cLU
 cLU
 cLU
 aQh
-cLU
-cLU
-cLU
-aam
+aaf
 aaf
 aaf
 cLU
@@ -85887,25 +86195,25 @@ brd
 bvU
 bEj
 bdP
-buQ
-bGt
-bGt
-bGt
-bGt
-fmR
-bGt
-bGt
-bGt
-aaf
+cLU
+cLU
+cLU
+cLU
+aSC
+aSC
+uoa
+aSC
+aSC
+uJB
+cLU
+cLU
+cLU
 cLU
 cLU
 cLU
 cLU
 aQh
-cLU
-cLU
-cLU
-aam
+aaf
 aaf
 cLU
 cLU
@@ -86144,17 +86452,17 @@ bxW
 bxW
 bEl
 bdP
-bIZ
-pGo
-bMg
-bMg
-bKI
-bPb
-vHf
-xpO
+buQ
 bGt
-cLU
-cLU
+bGt
+bGt
+aSC
+bNg
+hbt
+wiC
+aSC
+aaf
+aaf
 cLU
 cLU
 cLU
@@ -86401,17 +86709,17 @@ brf
 brf
 bEk
 aLF
-bJb
-bKK
-bKK
-bKK
-bKK
-bPc
-bKK
-dMi
-bGt
+bIZ
+ktz
+pWN
+btV
+aSC
+bMs
+gny
+wAA
+aSC
 cLU
-cLU
+aaf
 cLU
 cLU
 cLU
@@ -86431,10 +86739,10 @@ cLU
 aaf
 cLU
 cLU
-cLU
-cLU
-cLU
-cLU
+apc
+aQh
+aQh
+apc
 cLU
 cLU
 cLU
@@ -86659,15 +86967,15 @@ bzu
 bzu
 aLF
 bJb
-bHB
-bUk
-bzL
 bKK
-bPc
 bKK
-fTj
+bKK
 bGt
-cLU
+bGt
+fmR
+bGt
+bGt
+bGt
 cLU
 cLU
 cLU
@@ -86916,15 +87224,15 @@ bEm
 bHg
 aLF
 bJb
-bKH
-bWo
-gdx
-jfD
-bPc
+phI
+phI
 bKK
-bCx
+sgI
+cep
+bPb
+vHf
+xpO
 bGt
-cLU
 cLU
 cLU
 cLU
@@ -87173,15 +87481,15 @@ bdP
 bdP
 bdP
 bpd
-bLX
-cMF
+bHB
+bUk
+bzL
 bKK
 bKK
 bPc
-bKK
-bDH
+jfD
+dMi
 aSC
-cLU
 cLU
 cLU
 cLU
@@ -87430,23 +87738,23 @@ bCM
 bpo
 bGt
 bJb
-sgI
-iKS
-bMh
+bKH
+bWo
+gdx
 bJb
-bPc
+bKI
+hYG
 bKK
-bDH
+fTj
 aSC
 cLU
 cLU
 cLU
 cLU
 cLU
-apc
-aQh
-aQh
-apc
+cLU
+cLU
+cLU
 aaf
 cLU
 cLU
@@ -87687,15 +87995,15 @@ bga
 bEq
 bGt
 fPv
-bGt
-bGt
+cMF
+bLX
 bMj
 bJb
 buo
+bMg
 bKK
-lHF
+oBL
 bGt
-aaf
 cLU
 cLU
 cLU
@@ -87947,13 +88255,13 @@ bHA
 bJa
 jsn
 bMi
+bDv
 bKK
-btV
-bCy
-bRV
+lKF
+bKK
+rAu
 aSC
 aaf
-cLU
 cLU
 cLU
 cLU
@@ -88207,13 +88515,13 @@ bMl
 bNt
 bPm
 bDR
+bCy
 bRV
 aSC
 aaf
 cLU
 cLU
 cLU
-aaf
 cLU
 cLU
 cLU
@@ -88464,14 +88772,14 @@ bMk
 bNs
 bPi
 bCA
+kkU
 bRV
 bGt
 aaf
 cLU
 cLU
 cLU
-aaf
-aaf
+cLU
 cLU
 cLU
 aaf
@@ -88721,14 +89029,14 @@ bMn
 bGv
 bGv
 bEU
+fUi
+bRV
 bGt
-bGt
+aaf
 aaf
 bVO
 bUu
 bVO
-cLU
-aaf
 aaf
 aaf
 aaf
@@ -88978,6 +89286,8 @@ bMm
 bNz
 bGv
 bEe
+hmY
+bNx
 bNx
 bNx
 bUv
@@ -88987,10 +89297,8 @@ bVO
 bZf
 bfY
 bsR
+bZg
 cej
-cej
-aZR
-aZR
 aZR
 aZR
 aZR
@@ -89234,9 +89542,11 @@ bKO
 bMo
 bNH
 bGv
-bFE
-bFO
+bQv
+bVT
 cxK
+bNx
+bKg
 bUv
 bVO
 bVM
@@ -89244,10 +89554,8 @@ bVO
 bZf
 bhs
 bvV
-cej
+bZg
 bPe
-cgU
-cgU
 cgU
 cfJ
 cgU
@@ -89494,6 +89802,8 @@ bGv
 bQv
 bVT
 cxK
+bNx
+bKg
 bUv
 bTZ
 bVN
@@ -89501,11 +89811,9 @@ bTZ
 bZf
 bgb
 buy
-cej
+bZg
 bOS
-cgU
 cfJ
-chf
 cgU
 cgU
 chi
@@ -89752,16 +90060,16 @@ bQv
 bFL
 bFR
 bNx
+bKg
+bNx
 bVS
 bbA
 bJR
 bZg
 bjF
 buy
-cnp
-cep
-cgU
-chf
+ccY
+thZ
 chf
 chf
 chf
@@ -90010,15 +90318,15 @@ bFL
 ccx
 bNx
 bNx
+bNx
+bNx
 bHt
 bNx
 bZg
 bLM
 bzd
-cej
-ccY
-chf
-chf
+bZg
+mFy
 chf
 chf
 chf
@@ -90265,6 +90573,8 @@ bKm
 bNl
 bYE
 cbr
+blx
+blx
 bSj
 ccz
 bIs
@@ -90272,12 +90582,10 @@ cxK
 bZg
 bMN
 cbu
-cej
-cfx
+bZg
 cfG
 cgO
 cjL
-chf
 cms
 cnr
 cnD
@@ -90524,17 +90832,17 @@ bxI
 bTn
 bRS
 bRS
+bRS
+bRS
 bUM
 bNx
 bZg
 bmL
 bKn
-cej
-cej
+bZg
 cej
 cej
 cmm
-cej
 cej
 cnD
 cnD
@@ -90780,18 +91088,18 @@ bQx
 bNw
 cct
 bNw
+bNw
 bVU
+bNw
 bII
-bKg
-blx
 byk
-bLu
+dar
 cey
-bLP
+bLu
 bNv
 cbv
+rgy
 cjN
-ckM
 bwP
 bxG
 bLY
@@ -91040,8 +91348,8 @@ aSK
 bNx
 bNx
 bNx
-blw
-bra
+bRS
+bZg
 ccC
 cew
 cfH

--- a/maps/exodus/exodus_unit_testing.dm
+++ b/maps/exodus/exodus_unit_testing.dm
@@ -39,7 +39,6 @@
 		/area/exodus/storage/emergency = NO_SCRUBBER|NO_VENT,
 		/area/exodus/storage/emergency2 = NO_SCRUBBER|NO_VENT,
 		/area/ship/exodus_pod_engineering = NO_SCRUBBER|NO_VENT,
-		/area/ship/exodus_pod_mining = NO_SCRUBBER,
 		/area/ship/exodus_pod_research = NO_SCRUBBER
 	)
 


### PR DESCRIPTION
## Description of changes
Remapped the Mining Shuttle yet again, slight redesign of mining and the maintenance behind it to accommodate. 
Addition of some missing medical equipment to medical. 

## Why and what will this PR improve
Should be the final time we have to touch the mining shuttle sans any flaws or bugs that will be discovered. But it should be big enough for all of mining's needs for jaunts to exoplanets. Also allows us to test the shuttle design for our next map. 

Medical stuff is important stuff like the rescue bags and auto-cpr machines, along with some qol things like the vitals monitors.

## Authorship
Woodrat

## Changelog
:cl:
add: Replaced Mining shuttle with a Cynosure lite shuttle
add: Breath masks to shelves in mining
add: Rescue bags to medical
add: Vital monitors to surgery
add: Body scan displays to medical
add: Washing machine, iron board and related items to medical
add: Auto-compressors to medical
add: Lollipops Jar to medical
tweak: Remap of the mining dock and adjustment of maintenance behind
del: One sink from medical
/:cl: