### PR TITLE
Yet another Exodus Map Tweak

### DIFF
--- a/maps/exodus/exodus-2.dmm
+++ b/maps/exodus/exodus-2.dmm
@@ -20710,16 +20710,17 @@
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/quartermaster/storage)
 "aRC" = (
-/obj/machinery/door/airlock/external/bolted{
-	id_tag = "research_dock_outer";
-	name = "Shuttle Airlock"
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 5
 	},
-/obj/machinery/shield_diffuser,
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
-/turf/floor/tiled/techfloor/grid,
-/area/exodus/research/docking)
+/obj/structure/handrail{
+	dir = 4
+	},
+/turf/floor/airless,
+/area/ship/exodus_pod_research)
 "aRD" = (
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/secondary/entry/port)
@@ -29343,11 +29344,9 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable/green{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
 /turf/floor/tiled/white,
 /area/exodus/research/docking)
@@ -29377,23 +29376,11 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/secondary/entry/aft)
 "bkr" = (
-/obj/machinery/button/access/interior{
-	id_tag = "research_dock_airlock";
-	name = "interior access button";
-	pixel_x = 25;
-	pixel_y = -25
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
 	},
 /turf/floor/tiled/white,
 /area/exodus/research/docking)
@@ -29411,17 +29398,15 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/secondary/entry/aft)
 "bkt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+/obj/structure/handrail{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/blue/diagonal{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/floor/tiled/white,
-/area/exodus/research/docking)
+/turf/floor/tiled/steel_grid,
+/area/ship/exodus_pod_research)
 "bku" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/camera/network/civilian_west{
@@ -29681,18 +29666,21 @@
 /turf/wall/prepainted,
 /area/exodus/maintenance/disposal)
 "bkU" = (
-/obj/machinery/door/airlock/external/bolted{
-	id_tag = "research_dock_inner";
-	name = "Shuttle Airlock"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	id_tag = "research_shuttle_pump"
+	},
+/obj/machinery/oxygen_pump{
+	pixel_y = -32;
+	dir = 1
+	},
 /turf/floor/tiled/techfloor/grid,
-/area/exodus/research/docking)
+/area/ship/exodus_pod_research)
 "bkV" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/shutters/open{
@@ -32748,12 +32736,10 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/storage)
 "brg" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	icon_state = "2-8"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
-/turf/floor/plating,
+/turf/floor/tiled/steel_grid,
 /area/ship/exodus_pod_research)
 "brh" = (
 /turf/wall/r_wall/prepainted,
@@ -33959,13 +33945,22 @@
 /turf/wall/r_wall/prepainted,
 /area/exodus/hallway/primary/central_three)
 "btH" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/door/firedoor,
 /obj/structure/sign/warning/airlock{
 	pixel_y = -32;
 	dir = 1
 	},
-/turf/floor/plating,
+/obj/machinery/door/airlock/external/bolted{
+	id_tag = "research_dock_inner";
+	name = "Shuttle Airlock"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/floor/tiled/techfloor,
 /area/exodus/research/docking)
 "btI" = (
 /obj/structure/table{
@@ -35086,17 +35081,11 @@
 /turf/floor/bluegrid,
 /area/exodus/turret_protected/ai_upload)
 "bvO" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/industrial/warning/cee{
-	dir = 1;
-	icon_state = "warningcee"
-	},
-/obj/machinery/atmospherics/unary/tank/air{
-	dir = 4
-	},
-/turf/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/rust/mono_rusted3,
+/obj/item/radio/beacon,
+/turf/floor/tiled/steel_grid,
 /area/ship/exodus_pod_research)
 "bvP" = (
 /obj/machinery/light,
@@ -35495,9 +35484,12 @@
 /turf/floor/plating,
 /area/exodus/maintenance/engineering)
 "bwJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red,
-/obj/machinery/hologram/holopad/longrange,
-/turf/floor/tiled/white,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/closet/crate/secure/shuttle,
+/turf/floor/tiled/monotile,
 /area/ship/exodus_pod_research)
 "bwK" = (
 /obj/structure/disposalpipe/segment,
@@ -36032,17 +36024,15 @@
 /turf/floor/tiled/dark,
 /area/exodus/research)
 "bxQ" = (
-/obj/structure/catwalk,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
 	},
-/obj/item/radio/beacon,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 10
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup,
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/floor/plating,
+/turf/floor/tiled/techfloor/grid,
 /area/ship/exodus_pod_research)
 "bxR" = (
 /obj/machinery/conveyor{
@@ -36237,13 +36227,14 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/crew_quarters/heads/hop)
 "byn" = (
-/obj/machinery/computer/shuttle_control/explore/research{
-	dir = 8
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/window/reinforced{
-	dir = 4
+	dir = 1
 	},
-/turf/floor/tiled/white,
+/turf/floor/tiled/monotile,
 /area/ship/exodus_pod_research)
 "byo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -36965,26 +36956,20 @@
 /turf/floor/tiled/dark,
 /area/exodus/turret_protected/ai_server_room)
 "bzN" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/red{
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/power/terminal{
 	dir = 4
-	},
-/turf/floor/tiled/white,
-/area/ship/exodus_pod_research)
-"bzO" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	level = 2;
-	dir = 1
 	},
 /obj/structure/cable/green{
-	icon_state = "1-2"
+	icon_state = "0-8"
 	},
-/turf/floor/tiled/white,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/floor/tiled/techmaint,
+/area/ship/exodus_pod_research)
+"bzO" = (
+/turf/wall/titanium,
 /area/ship/exodus_pod_research)
 "bzP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -37167,11 +37152,14 @@
 /turf/wall/r_wall/prepainted,
 /area/exodus/turret_protected/ai_server_room)
 "bAi" = (
-/obj/machinery/computer/shuttle_control/research{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/floor/tiled/white,
 /area/exodus/research/docking)
@@ -38309,16 +38297,10 @@
 /turf/floor/tiled/white,
 /area/exodus/research/xenobiology)
 "bCr" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/network/relay/long_range,
-/obj/structure/window/reinforced{
+/obj/structure/handrail{
 	dir = 4
 	},
-/obj/structure/window/reinforced,
-/turf/floor/tiled/white,
+/turf/floor/tiled/steel_grid,
 /area/ship/exodus_pod_research)
 "bCs" = (
 /obj/structure/table,
@@ -39065,19 +39047,11 @@
 /turf/floor/tiled/dark,
 /area/exodus/research/server)
 "bDQ" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/effect/paint/red,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
-/obj/machinery/button/access/exterior{
-	id_tag = "research_shuttle";
-	pixel_x = 26;
-	pixel_y = -16;
-	directional_offset = null
-	},
-/obj/machinery/door/airlock/external/bolted{
-	id_tag = "research_shuttle_outer"
-	},
-/turf/floor/tiled/techfloor/grid,
+/turf/wall/titanium,
 /area/ship/exodus_pod_research)
 "bDR" = (
 /obj/structure/disposalpipe/segment{
@@ -40125,14 +40099,8 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/port)
 "bFW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -40146,15 +40114,20 @@
 /turf/wall/r_wall/prepainted,
 /area/exodus/research/mixing)
 "bFY" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 8;
-	id_tag = "research_dock_pump"
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 8;
+	id_tag = "research_dock_airlock";
+	pixel_x = 25;
+	tag_airpump = "research_dock_pump";
+	tag_chamber_sensor = "research_dock_sensor";
+	tag_exterior_door = "research_dock_outer";
+	tag_interior_door = "research_dock_inner"
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/research/docking)
@@ -40940,8 +40913,21 @@
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/warning/corner{
+/obj/effect/floor_decal/industrial/warning{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/button/access/interior{
+	id_tag = "research_dock_airlock";
+	name = "interior access button";
+	pixel_x = 25;
+	pixel_y = 25;
+	dir = 8
 	},
 /turf/floor/tiled/white,
 /area/exodus/research/docking)
@@ -40957,12 +40943,12 @@
 	pixel_y = -25;
 	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 1;
-	id_tag = "research_dock_pump"
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/research/docking)
@@ -40985,20 +40971,15 @@
 /turf/floor/tiled/white,
 /area/exodus/research/docking)
 "bHz" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	dir = 8;
-	id_tag = "research_dock_airlock";
-	pixel_x = 25;
-	tag_airpump = "research_dock_pump";
-	tag_chamber_sensor = "research_dock_sensor";
-	tag_exterior_door = "research_dock_outer";
-	tag_interior_door = "research_dock_inner"
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	dir = 8;
+	id_tag = "research_dock_pump"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/research/docking)
@@ -43316,6 +43297,9 @@
 /area/exodus/quartermaster/miningdock)
 "bMh" = (
 /obj/structure/bed/chair/shuttle/black,
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
 /turf/floor/tiled/steel_grid,
 /area/ship/exodus_pod_mining)
 "bMi" = (
@@ -44005,14 +43989,17 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
 "bNu" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/machinery/power/smes/buildable{
+	RCon_tag = "Shuttle - Research";
+	charge = 1e+007;
+	input_attempt = 1;
+	input_level = 1e+006;
+	output_attempt = 1;
+	output_level = 1e+006
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/floor/plating,
+/obj/structure/cable/cyan,
+/obj/effect/floor_decal/industrial/warning/full,
+/turf/floor/tiled/techfloor/grid,
 /area/ship/exodus_pod_research)
 "bNv" = (
 /obj/machinery/alarm{
@@ -63433,17 +63420,10 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/teleporter)
 "cSp" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 5
-	},
-/turf/floor/plating,
+/turf/floor/tiled/steel_grid,
 /area/ship/exodus_pod_research)
 "cUO" = (
 /obj/machinery/computer/ship/helm{
@@ -63493,25 +63473,8 @@
 /turf/wall/titanium,
 /area/ship/exodus_pod_mining)
 "dmw" = (
-/obj/machinery/power/apc/critical{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/floor/plating,
+/obj/machinery/computer/shuttle_control/explore/research,
+/turf/floor/tiled/monotile,
 /area/ship/exodus_pod_research)
 "doN" = (
 /obj/abstract/level_data_spawner/main_level{
@@ -63527,6 +63490,20 @@
 "drR" = (
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/storage/emergency)
+"dti" = (
+/obj/machinery/computer/ship/helm,
+/obj/effect/overmap/visitable/ship/landable/pod/research,
+/turf/floor/tiled/monotile,
+/area/ship/exodus_pod_research)
+"dul" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/structure/handrail{
+	dir = 1
+	},
+/turf/floor/tiled/techmaint,
+/area/ship/exodus_pod_research)
 "dvY" = (
 /obj/machinery/vending/snack{
 	dir = 4
@@ -63562,14 +63539,10 @@
 /turf/floor/tiled/dark/monotile,
 /area/shuttle/arrival/station)
 "dKo" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/machinery/door/airlock/hatch,
-/turf/floor/tiled/techfloor/grid,
+/turf/floor/tiled/techmaint,
 /area/ship/exodus_pod_research)
 "dKq" = (
 /obj/effect/floor_decal/corner/blue{
@@ -63638,26 +63611,26 @@
 	},
 /turf/wall/titanium,
 /area/ship/exodus_pod_mining)
+"ehn" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced,
+/obj/machinery/cell_charger,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/floor/tiled/monotile,
+/area/ship/exodus_pod_research)
 "ejv" = (
-/obj/effect/shuttle_landmark/research_pod_dock,
-/obj/structure/cable/green{
-	icon_state = "2-8"
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 6
 	},
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/bed/chair/shuttle/black{
+	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	id_tag = "research_shuttle_pump_out_internal";
-	dir = 4
-	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	cycle_to_external_air = 1;
-	id_tag = "research_shuttle";
-	tag_interior_sensor = "research_interior_sensor";
-	tag_pump_out_external = "research_pump_out_external";
-	pixel_y = 25
-	},
-/turf/floor/tiled/techfloor/grid,
+/obj/machinery/light,
+/turf/floor/tiled/monotile,
 /area/ship/exodus_pod_research)
 "ejT" = (
 /obj/machinery/computer/ship/engines{
@@ -63726,25 +63699,29 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/starboard)
 "eTV" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	id_tag = "research_shuttle_pump";
-	dir = 8
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
 	},
-/turf/floor/tiled/techfloor/grid,
-/area/ship/exodus_pod_research)
-"eWD" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	id_tag = "research_shuttle_pump";
-	dir = 8
+	id_tag = "research_shuttle_pump"
 	},
-/obj/machinery/airlock_sensor{
-	id_tag = "research_shuttle_sensor";
-	pixel_y = 25
+/obj/machinery/oxygen_pump{
+	pixel_y = -32;
+	dir = 1
 	},
 /turf/floor/tiled/techfloor/grid,
+/area/ship/exodus_pod_research)
+"eWD" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/floor/tiled/steel_grid,
 /area/ship/exodus_pod_research)
 "eZK" = (
 /obj/effect/floor_decal/corner/purple,
@@ -63808,13 +63785,11 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/starboard)
 "fyf" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 5
-	},
-/turf/floor/plating,
-/area/ship/exodus_pod_research)
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate/secure/shuttle,
+/turf/floor/tiled/monotile,
+/area/ship/exodus_pod_mining)
 "fCE" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -63890,6 +63865,20 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
+"gfW" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_y = -32;
+	dir = 1
+	},
+/obj/structure/bed/chair/shuttle/black{
+	dir = 1
+	},
+/turf/floor/tiled/monotile,
+/area/ship/exodus_pod_research)
 "gny" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
@@ -63927,15 +63916,12 @@
 /turf/floor/plating,
 /area/ship/exodus_pod_engineering)
 "gyJ" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	level = 2;
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/floor/tiled/steel_grid,
+/obj/structure/closet/emcloset,
+/turf/floor/tiled/monotile,
 /area/ship/exodus_pod_research)
 "gAA" = (
 /obj/effect/floor_decal/corner/lime{
@@ -63966,19 +63952,13 @@
 /turf/floor/tiled/dark/monotile,
 /area/shuttle/arrival/station)
 "gSL" = (
-/obj/machinery/power/smes/buildable{
-	RCon_tag = "Engine - Main";
-	charge = 1e+007;
-	input_attempt = 1;
-	input_level = 1e+006;
-	output_attempt = 1;
-	output_level = 1e+006
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/obj/effect/floor_decal/industrial/warning/full,
-/turf/floor/plating,
+/turf/floor/tiled/techmaint,
 /area/ship/exodus_pod_research)
 "hbj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -64002,9 +63982,18 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/port)
 "hiz" = (
-/obj/machinery/shipsensors/weak,
-/obj/structure/cable/green,
-/turf/floor/plating,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/atmospherics/pipe/manifold/hidden/red{
+	dir = 1
+	},
+/obj/structure/bed/chair/shuttle/black{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/floor/tiled/monotile,
 /area/ship/exodus_pod_research)
 "hkD" = (
 /obj/machinery/light_switch{
@@ -64035,22 +64024,9 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/engineering)
 "hpP" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/floor/tiled/white,
+/obj/effect/floor_decal/industrial/warning/full,
+/obj/machinery/shipsensors/weak,
+/turf/floor/airless,
 /area/ship/exodus_pod_research)
 "hsk" = (
 /obj/machinery/power/smes/buildable{
@@ -64139,16 +64115,38 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
 "hZw" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+/obj/machinery/hologram/holopad/longrange,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/effect/floor_decal/steeldecal/steel_decals3{
 	dir = 1
 	},
-/obj/machinery/door/airlock/external/bolted{
-	id_tag = "research_shuttle_inner"
+/obj/effect/floor_decal/steeldecal/steel_decals3{
+	dir = 10
 	},
-/turf/floor/tiled/techfloor/grid,
+/obj/effect/floor_decal/steeldecal/steel_decals3{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals3{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals3{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals3,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/floor/tiled/monotile,
+/area/ship/exodus_pod_research)
+"icm" = (
+/obj/effect/paint/red,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 6
+	},
+/turf/wall/titanium,
 /area/ship/exodus_pod_research)
 "idh" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -64159,13 +64157,13 @@
 /turf/floor/tiled/techmaint,
 /area/ship/exodus_pod_mining)
 "idY" = (
-/obj/structure/cable/cyan{
-	icon_state = "1-8"
-	},
 /obj/structure/bed/chair/shuttle/black,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 4
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
 	},
 /turf/floor/tiled/monotile,
 /area/ship/exodus_pod_mining)
@@ -64174,6 +64172,15 @@
 /obj/abstract/landmark/latejoin/observer,
 /turf/floor/tiled/dark/monotile,
 /area/shuttle/arrival/station)
+"ihn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Passenger Compartment"
+	},
+/turf/floor/tiled/techfloor,
+/area/ship/exodus_pod_research)
 "ihN" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 1
@@ -64250,6 +64257,30 @@
 /obj/effect/floor_decal/industrial/warning/full,
 /turf/floor/tiled/techmaint,
 /area/ship/exodus_pod_mining)
+"iMR" = (
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/machinery/airlock_sensor{
+	dir = 4;
+	id_tag = "research_interior_sensor";
+	pixel_x = -25
+	},
+/obj/machinery/button/access/interior{
+	id_tag = "research_shuttle";
+	pixel_x = -20;
+	pixel_y = 5;
+	dir = 4
+	},
+/turf/floor/tiled/techmaint,
+/area/ship/exodus_pod_research)
 "iNs" = (
 /obj/effect/floor_decal/corner/white{
 	dir = 10
@@ -64303,6 +64334,9 @@
 "jfm" = (
 /obj/effect/floor_decal/rust/steel_decals_rusted2,
 /obj/structure/bed/chair/shuttle/black,
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
 /turf/floor/tiled/steel_grid,
 /area/ship/exodus_pod_mining)
 "jfD" = (
@@ -64336,7 +64370,7 @@
 /area/exodus/hallway/secondary/exit)
 "jxl" = (
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Engine - Main";
+	RCon_tag = "Shuttle - Mining";
 	charge = 1e+007;
 	input_attempt = 1;
 	input_level = 1e+006;
@@ -64374,6 +64408,16 @@
 /obj/effect/paint/red,
 /turf/wall/titanium,
 /area/ship/exodus_pod_research)
+"jQq" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/floor/tiled/techfloor/grid,
+/area/ship/exodus_pod_research)
 "jYD" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -64399,21 +64443,17 @@
 /turf/floor/plating,
 /area/space)
 "klX" = (
-/obj/structure/table{
-	name = "plastic table frame"
+/obj/machinery/door/window/southright{
+	name = "Cockpit"
 	},
-/obj/machinery/recharger,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/item/radio_beacon,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/floor/tiled/white,
+/turf/floor/tiled/steel_grid,
 /area/ship/exodus_pod_research)
 "ktz" = (
 /obj/effect/floor_decal/corner/brown{
@@ -64491,6 +64531,9 @@
 "leK" = (
 /obj/effect/floor_decal/rust/steel_decals_rusted1,
 /obj/structure/bed/chair/shuttle/black,
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
 /turf/floor/tiled/steel_grid,
 /area/ship/exodus_pod_mining)
 "lfJ" = (
@@ -64500,6 +64543,22 @@
 	},
 /turf/floor/tiled/freezer,
 /area/shuttle/arrival/station)
+"lmu" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister,
+/turf/floor/tiled/techfloor/grid,
+/area/ship/exodus_pod_research)
+"lvK" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/turf/floor/plating,
+/area/ship/exodus_pod_research)
 "lyt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -64524,12 +64583,19 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/secondary/exit)
 "lDi" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	dir = 9
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
 	},
-/turf/floor/plating,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24;
+	locked = 0
+	},
+/obj/structure/table/reinforced,
+/obj/item/geiger,
+/obj/machinery/recharger,
+/turf/floor/tiled/monotile,
 /area/ship/exodus_pod_research)
 "lDJ" = (
 /obj/effect/floor_decal/corner_steel_grid{
@@ -64557,19 +64623,10 @@
 /turf/floor/tiled/dark,
 /area/ship/exodus_pod_engineering)
 "lGI" = (
-/obj/machinery/computer/ship/sensors{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	dir = 4
+	dir = 5
 	},
-/turf/floor/tiled/white,
+/turf/wall/titanium,
 /area/ship/exodus_pod_research)
 "lHF" = (
 /obj/machinery/shipsensors/weak,
@@ -64586,12 +64643,24 @@
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
+"lNW" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/blue{
+	dir = 1
+	},
+/turf/floor/tiled/techmaint,
+/area/ship/exodus_pod_research)
 "miB" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
 	},
 /turf/floor/tiled/steel_grid,
 /area/ship/exodus_pod_mining)
@@ -64603,6 +64672,26 @@
 /obj/machinery/door/firedoor,
 /turf/floor/plating,
 /area/exodus/bridge)
+"mEc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals_central5{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/turf/floor/tiled/steel_grid,
+/area/ship/exodus_pod_research)
 "mFy" = (
 /obj/structure/table/steel,
 /obj/random/tech_supply,
@@ -64625,24 +64714,18 @@
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/engineering/workshop)
 "mLL" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green,
-/turf/floor/plating,
-/area/ship/exodus_pod_research)
+/turf/floor/tiled/monotile,
+/area/ship/exodus_pod_mining)
 "mNA" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	id_tag = "research_pump_out_external"
+/obj/machinery/atmospherics/pipe/manifold/hidden/red{
+	dir = 8
 	},
-/turf/floor/plating,
+/turf/wall/titanium,
 /area/ship/exodus_pod_research)
 "mNK" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
@@ -64656,14 +64739,9 @@
 /turf/floor/plating,
 /area/ship/exodus_pod_engineering)
 "mVl" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/turf/floor/plating,
+/obj/machinery/network/relay/long_range,
+/obj/structure/window/reinforced,
+/turf/floor/tiled/monotile,
 /area/ship/exodus_pod_research)
 "mYp" = (
 /obj/structure/bed/chair{
@@ -64719,17 +64797,32 @@
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/storage)
+"nKc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9
+	},
+/turf/wall/titanium,
+/area/ship/exodus_pod_research)
 "nLD" = (
-/obj/machinery/power/terminal{
-	dir = 8
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/turf/floor/plating,
+/area/ship/exodus_pod_research)
+"nMD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 5
 	},
-/obj/structure/cable/green{
-	icon_state = "0-4"
+/turf/wall/titanium,
+/area/ship/exodus_pod_research)
+"nNr" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/structure/bed/chair/shuttle/black{
+	dir = 1
 	},
-/turf/floor/tiled/steel_grid,
+/turf/floor/tiled/monotile,
 /area/ship/exodus_pod_research)
 "nOM" = (
 /obj/effect/floor_decal/corner/white{
@@ -64845,17 +64938,27 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
 "oDi" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/unary/engine{
+	dir = 1
 	},
-/obj/structure/window/reinforced{
+/turf/floor/airless,
+/area/ship/exodus_pod_research)
+"oJj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	id_tag = "research_shuttle_pump_out_internal";
-	dir = 4
+/turf/floor/tiled/techmaint,
+/area/ship/exodus_pod_research)
+"oLF" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 10
 	},
-/turf/floor/tiled/techfloor/grid,
+/obj/structure/bed/chair/shuttle/black{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/floor/tiled/monotile,
 /area/ship/exodus_pod_research)
 "oWh" = (
 /obj/machinery/network/requests_console{
@@ -64888,45 +64991,46 @@
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
+"pmd" = (
+/obj/effect/floor_decal/industrial/warning/full,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 10
+	},
+/obj/structure/fuel_port{
+	pixel_y = null
+	},
+/turf/floor/tiled/techmaint,
+/area/ship/exodus_pod_research)
 "pnI" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4;
-	icon_state = "warning"
-	},
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/air/airlock{
-	start_pressure = 730
-	},
-/turf/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/red,
+/turf/wall/titanium,
 /area/ship/exodus_pod_research)
 "poU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/floor/tiled/dark,
 /area/exodus/chapel/main)
 "pqS" = (
-/obj/structure/bed/chair{
-	dir = 4
+/obj/machinery/atmospherics/binary/pump/on{
+	dir = 4;
+	target_pressure = 315
 	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/structure/sign/warning/airlock{
+	pixel_y = -32;
+	dir = 1
 	},
-/turf/floor/tiled/white,
+/obj/structure/handrail{
+	dir = 1
+	},
+/turf/floor/tiled/techmaint,
 /area/ship/exodus_pod_research)
 "pAd" = (
-/obj/structure/cable/green{
-	icon_state = "2-8"
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 10
 	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/turf/floor/plating,
+/obj/machinery/meter,
+/turf/floor/tiled/techmaint,
 /area/ship/exodus_pod_research)
 "pGo" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -64939,21 +65043,29 @@
 	},
 /turf/floor/tiled/techfloor/grid,
 /area/ship/exodus_pod_mining)
+"pMK" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/floor/tiled/monotile,
+/area/ship/exodus_pod_research)
 "pWa" = (
 /obj/effect/shuttle_landmark/exodus_main_fore,
 /turf/space,
 /area/space)
 "pWD" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	dir = 10
+/obj/machinery/door/airlock/external/bolted{
+	id_tag = "research_shuttle_inner"
 	},
-/turf/floor/tiled/steel_grid,
+/turf/floor/tiled/techfloor,
 /area/ship/exodus_pod_research)
 "pWN" = (
 /obj/effect/floor_decal/corner/brown{
@@ -64969,6 +65081,26 @@
 /obj/item/rig/industrial/equipped,
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
+"pYn" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	id_tag = "research_shuttle_pump_out_internal";
+	dir = 1
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	cycle_to_external_air = 1;
+	id_tag = "research_shuttle";
+	tag_interior_sensor = "research_interior_sensor";
+	tag_pump_out_external = "research_pump_out_external";
+	pixel_y = 25
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/floor/tiled/techfloor/grid,
+/area/ship/exodus_pod_research)
 "qfO" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 4;
@@ -65003,14 +65135,12 @@
 /turf/floor/tiled/monotile,
 /area/ship/exodus_pod_mining)
 "qvM" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	id_tag = "research_pump_out_external";
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/floor/plating,
+/obj/structure/grille,
+/turf/floor/airless,
 /area/ship/exodus_pod_research)
 "qBY" = (
 /obj/structure/cable/cyan{
@@ -65037,14 +65167,11 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/central_two)
 "qHp" = (
-/obj/machinery/light,
-/obj/structure/cable/green{
-	icon_state = "1-4"
+/obj/effect/paint/red,
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 1
 	},
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/turf/floor/tiled/white,
+/turf/wall/titanium,
 /area/ship/exodus_pod_research)
 "qHU" = (
 /obj/structure/cable/green{
@@ -65070,11 +65197,31 @@
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/engineering/engineering_monitoring)
-"qZa" = (
-/obj/machinery/computer/ship/engines{
+"qXq" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 4
 	},
-/turf/floor/tiled/steel_grid,
+/obj/structure/bed/chair/shuttle/black{
+	dir = 1
+	},
+/turf/floor/tiled/monotile,
+/area/ship/exodus_pod_research)
+"qZa" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/blue{
+	dir = 5
+	},
+/obj/machinery/meter,
+/obj/structure/handrail{
+	dir = 1
+	},
+/turf/floor/tiled/techmaint,
 /area/ship/exodus_pod_research)
 "rgy" = (
 /obj/machinery/light/small{
@@ -65100,6 +65247,24 @@
 	},
 /turf/wall/titanium,
 /area/ship/exodus_pod_mining)
+"rjQ" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
+/obj/machinery/button/alternate/door/bolts{
+	id_tag = "rhatch";
+	name = "Rear Hatch Release";
+	pixel_x = -24;
+	req_access = list("ACCESS_RESEARCH")
+	},
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Rear Hatch";
+	id_tag = "rhatch";
+	autoset_access = 0;
+	stock_part_presets = list(/decl/stock_part_preset/radio/receiver/airlock = 1, /decl/stock_part_preset/radio/event_transmitter/airlock = 1)
+	},
+/turf/floor/tiled/techfloor,
+/area/ship/exodus_pod_research)
 "rkN" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
@@ -65143,6 +65308,16 @@
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
+"rIN" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/floor/tiled/techmaint,
+/area/ship/exodus_pod_research)
 "rNu" = (
 /obj/structure/table{
 	name = "plastic table frame"
@@ -65179,6 +65354,11 @@
 	},
 /turf/floor/tiled/monotile,
 /area/ship/exodus_pod_mining)
+"rPX" = (
+/obj/effect/floor_decal/industrial/outline,
+/obj/machinery/recharge_station,
+/turf/floor/tiled/monotile,
+/area/ship/exodus_pod_research)
 "rQB" = (
 /obj/effect/paint_stripe/yellow,
 /turf/wall/titanium,
@@ -65192,14 +65372,6 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/secondary/entry/port)
 "rVT" = (
-/obj/structure/cable/cyan{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
 /obj/structure/bed/chair/shuttle/black,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
@@ -65210,6 +65382,15 @@
 "rXI" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
+/obj/structure/cable/cyan{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24;
+	locked = 0
+	},
+/obj/item/geiger,
 /turf/floor/tiled/monotile,
 /area/ship/exodus_pod_mining)
 "rYD" = (
@@ -65276,14 +65457,9 @@
 /turf/floor/tiled/techfloor,
 /area/exodus/engineering/storage)
 "sxY" = (
-/obj/effect/overmap/visitable/ship/landable/pod/research,
-/obj/machinery/computer/ship/helm{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/floor/tiled/white,
+/obj/effect/floor_decal/industrial/outline,
+/obj/machinery/sleeper/standard,
+/turf/floor/tiled/monotile,
 /area/ship/exodus_pod_research)
 "syF" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -65387,6 +65563,18 @@
 	},
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/engineering)
+"tgk" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/shield_diffuser,
+/obj/machinery/door/airlock/external/bolted{
+	id_tag = "research_dock_outer";
+	name = "Shuttle Airlock"
+	},
+/turf/floor/tiled/techfloor,
+/area/exodus/research/docking)
 "thZ" = (
 /obj/structure/table/steel,
 /obj/random/tech_supply,
@@ -65437,12 +65625,17 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/starboard)
 "tCN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+/obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
 	},
-/turf/floor/tiled/steel_grid,
-/area/ship/exodus_pod_research)
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/floor/tiled/white,
+/area/exodus/research/docking)
 "tDI" = (
 /obj/effect/floor_decal/corner/purple,
 /obj/machinery/camera/network/research{
@@ -65452,44 +65645,38 @@
 /turf/floor/tiled/white,
 /area/exodus/research)
 "tGf" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/machinery/button/access/exterior{
+	id_tag = "research_dock_airlock";
+	name = "exterior access button";
+	pixel_x = 5;
+	pixel_y = 25
 	},
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
-/obj/structure/handrail{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/floor/plating,
-/area/ship/exodus_pod_research)
+/turf/space,
+/area/space)
 "tGo" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/machinery/door/firedoor,
 /turf/floor/plating,
 /area/ship/exodus_pod_mining)
+"tJT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/floor/tiled/steel_grid,
+/area/ship/exodus_pod_research)
 "tQY" = (
-/obj/structure/catwalk,
-/obj/machinery/button/access/interior{
-	id_tag = "research_shuttle";
-	pixel_x = 20;
-	pixel_y = 5;
-	dir = 8
+/obj/effect/paint/red,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 10
 	},
-/obj/machinery/airlock_sensor{
-	dir = 1;
-	id_tag = "research_interior_sensor";
-	pixel_y = -25
-	},
-/turf/floor/plating,
+/turf/wall/titanium,
 /area/ship/exodus_pod_research)
 "tRc" = (
-/obj/effect/paint_stripe/mauve,
-/turf/wall/titanium,
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/floor/tiled/steel_grid,
 /area/ship/exodus_pod_research)
 "tUa" = (
 /obj/structure/cable/green{
@@ -65520,6 +65707,19 @@
 	},
 /turf/floor/tiled/techmaint,
 /area/ship/exodus_pod_mining)
+"tXS" = (
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock{
+	start_pressure = 730
+	},
+/turf/floor/tiled/techfloor/grid,
+/area/ship/exodus_pod_research)
 "tYK" = (
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 10
@@ -65543,6 +65743,12 @@
 	},
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/quartermaster/miningdock)
+"uoP" = (
+/obj/machinery/computer/ship/engines{
+	dir = 8
+	},
+/turf/floor/tiled/monotile,
+/area/ship/exodus_pod_research)
 "uFU" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -65595,6 +65801,13 @@
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/central_one)
+"vcz" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/unary/tank/air{
+	dir = 8
+	},
+/turf/floor/tiled/techfloor/grid,
+/area/ship/exodus_pod_research)
 "vfH" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/floor/tiled/steel_grid,
@@ -65626,6 +65839,32 @@
 	},
 /turf/floor/tiled/monotile,
 /area/ship/exodus_pod_mining)
+"vtz" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/external/bolted{
+	id_tag = "research_shuttle_outer"
+	},
+/obj/machinery/button/access/exterior{
+	id_tag = "research_shuttle";
+	pixel_x = -16;
+	pixel_y = -26;
+	directional_offset = null;
+	dir = 8
+	},
+/turf/floor/tiled/techfloor,
+/area/ship/exodus_pod_research)
+"vuh" = (
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/structure/bed/chair/shuttle/black{
+	dir = 1
+	},
+/turf/floor/tiled/steel_grid,
+/area/ship/exodus_pod_research)
 "vAy" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -65634,12 +65873,13 @@
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /turf/floor/plating,
 /area/ship/exodus_pod_mining)
+"vFG" = (
+/obj/machinery/computer/ship/sensors,
+/turf/floor/tiled/monotile,
+/area/ship/exodus_pod_research)
 "vHf" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
-	},
-/obj/machinery/computer/shuttle_control/mining{
-	dir = 4
 	},
 /obj/structure/sign/warning/airlock{
 	pixel_x = -32;
@@ -65665,8 +65905,17 @@
 /obj/machinery/door/window/northleft{
 	name = "Cockpit"
 	},
+/obj/item/radio_beacon,
 /turf/floor/tiled/steel_grid,
 /area/ship/exodus_pod_mining)
+"vLB" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup,
+/turf/floor/tiled/techfloor/grid,
+/area/ship/exodus_pod_research)
 "vPY" = (
 /obj/structure/table/reinforced,
 /obj/item/gps,
@@ -65683,21 +65932,33 @@
 /turf/floor/tiled/techmaint,
 /area/ship/exodus_pod_mining)
 "vSZ" = (
-/obj/structure/cable/green{
-	icon_state = "0-4"
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
 	},
-/obj/machinery/ion_thruster{
-	dir = 4;
-	icon_state = "nozzle"
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/turf/floor/plating,
+/turf/floor/tiled/steel_grid,
+/area/ship/exodus_pod_research)
+"vUA" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/structure/bed/chair/shuttle/black{
+	dir = 1
+	},
+/turf/floor/tiled/steel_grid,
 /area/ship/exodus_pod_research)
 "vVU" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/structure/cable/green{
-	icon_state = "1-8"
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
 	},
-/turf/floor/plating,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/turf/floor/tiled/techmaint,
 /area/ship/exodus_pod_research)
 "wby" = (
 /turf/floor/tiled/techfloor/grid,
@@ -65792,6 +66053,20 @@
 	},
 /turf/floor/tiled/dark/monotile,
 /area/shuttle/arrival/station)
+"wsP" = (
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/floor/tiled/techmaint,
+/area/ship/exodus_pod_research)
 "wAA" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -65851,6 +66126,23 @@
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/central_two)
+"xam" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/shuttle_landmark/research_pod_dock,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/turf/floor/tiled/techmaint,
+/area/ship/exodus_pod_research)
 "xfi" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
 	dir = 1
@@ -65872,6 +66164,20 @@
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/central_two)
+"xoi" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	id_tag = "research_shuttle_pump_out_internal";
+	dir = 1
+	},
+/obj/machinery/airlock_sensor{
+	id_tag = "research_shuttle_sensor";
+	pixel_y = 25
+	},
+/turf/floor/tiled/techfloor/grid,
+/area/ship/exodus_pod_research)
 "xpO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/fabricator/industrial,
@@ -65925,17 +66231,14 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/port)
 "xHt" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1
-	},
 /obj/machinery/camera/network/research{
 	c_tag = "Research Shuttle Dock Airlock"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	id_tag = "research_dock_pump"
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/research/docking)
@@ -65943,8 +66246,22 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
 /turf/floor/tiled/steel_grid,
 /area/ship/exodus_pod_mining)
+"xKT" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
+/obj/machinery/meter,
+/obj/structure/handrail{
+	dir = 1
+	},
+/turf/floor/tiled/techmaint,
+/area/ship/exodus_pod_research)
 "xOe" = (
 /obj/machinery/door/firedoor,
 /turf/floor/tiled/white,
@@ -65955,6 +66272,10 @@
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/office)
+"xUH" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
+/turf/wall/titanium,
+/area/ship/exodus_pod_research)
 "xVx" = (
 /obj/structure/bed/chair/shuttle/black{
 	dir = 8
@@ -84407,7 +84728,7 @@ cnp
 bNr
 rVT
 tzU
-dcK
+fyf
 okm
 ejT
 bNr
@@ -84664,7 +84985,7 @@ qBY
 vAy
 idY
 xJn
-tpe
+mLL
 miB
 jfm
 vnz
@@ -85435,7 +85756,7 @@ blw
 nZs
 bCx
 nWl
-tpe
+dcK
 xva
 rXI
 bNr
@@ -116519,8 +116840,8 @@ bjl
 bBj
 bCB
 bEd
-bkt
 bHw
+tCN
 bCJ
 aaf
 cLU
@@ -116776,8 +117097,8 @@ bjl
 aPa
 aPa
 aMM
-bkt
 bHw
+tCN
 aPa
 aaf
 cLU
@@ -117026,15 +117347,15 @@ cLU
 cLU
 cLU
 cLU
-jMk
-vSZ
-vSZ
-vSZ
-vSZ
-jMk
+cLU
+cLU
+cLU
+cLU
+cLU
+cLU
 aMM
-bkt
 bHw
+tCN
 aPa
 aaf
 cLU
@@ -117283,15 +117604,15 @@ cLU
 cLU
 cLU
 cLU
-tRc
-mVl
-pAd
-mLL
-vVU
-tRc
+cLU
+cLU
+cLU
+cLU
+cLU
+cLU
 aMM
-bkt
 bHw
+tCN
 aPa
 aaf
 cLU
@@ -117540,15 +117861,15 @@ cLU
 cLU
 cLU
 cLU
-tRc
-bvO
-pnI
-gSL
-qZa
-tRc
+cLU
+cLU
+cLU
+cLU
+cLU
+cLU
 aMM
 bFW
-bHw
+tCN
 aPa
 aaf
 aaf
@@ -117797,15 +118118,15 @@ cLU
 cLU
 cLU
 cLU
-tRc
-pWD
-tCN
-nLD
-gyJ
-tRc
-aMM
-bkt
+cLU
+cLU
+cLU
+aIv
+cLU
+cLU
+aPa
 bHw
+tCN
 aPa
 aaf
 cLU
@@ -118054,12 +118375,12 @@ cLU
 cLU
 cLU
 cLU
-buR
-qvM
-bxQ
-cSp
-tQY
-buR
+cLU
+cLU
+cLU
+cLU
+cLU
+cLU
 aPa
 bkr
 bHv
@@ -118311,14 +118632,14 @@ cLU
 cLU
 cLU
 cLU
-tRc
-tGf
-tRc
-hZw
-fyf
-tRc
+cLU
+cLU
+cLU
+cLU
+cLU
+cLU
+bCJ
 aPa
-bkU
 btH
 bCJ
 cLU
@@ -118568,12 +118889,12 @@ cLU
 cLU
 cLU
 cLU
-tRc
-bNu
-buR
-eWD
-eTV
-buR
+cLU
+cLU
+cLU
+cLU
+cLU
+cLU
 aPa
 xHt
 bHx
@@ -118825,13 +119146,13 @@ cLU
 cLU
 cLU
 cLU
-tRc
-dKo
-buR
-ejv
-oDi
-bDQ
-aRC
+cLU
+cLU
+cLU
+cLU
+cLU
+cLU
+aPa
 bFY
 bHz
 aPa
@@ -119082,20 +119403,20 @@ cLU
 cLU
 cLU
 cLU
-tRc
-dmw
-bwJ
-bzN
-klX
-tRc
+cLU
+cLU
+cLU
+cLU
+cLU
+cLU
 aMM
 aPa
+tgk
 bCJ
-bCJ
-cLU
+tGf
 cLU
 aaf
-cLU
+aaf
 aaf
 cLU
 crP
@@ -119339,20 +119660,20 @@ cLU
 cLU
 cLU
 cLU
-tRc
+cLU
 hpP
 bzO
-pqS
-qHp
-tRc
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-aaf
-cLU
+bzO
+bzO
+buR
+bzO
+nLD
+vtz
+bzO
+bzO
+bzO
+jMk
+jMk
 aaf
 cLU
 crP
@@ -119596,20 +119917,20 @@ cLU
 cLU
 cLU
 cLU
+bzO
 buR
-lGI
-byn
+bzO
 sxY
 bCr
-buR
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-aaf
-cLU
+ejv
+pnI
+xoi
+bkU
+nMD
+bxQ
+vLB
+icm
+oDi
 aaf
 cLU
 crP
@@ -119852,21 +120173,21 @@ cLU
 cLU
 cLU
 cLU
-cLU
-mNA
+bzO
+bzO
 lDi
-buR
-buR
+ehn
+gyJ
 brg
 hiz
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-aaf
-cLU
+pnI
+pYn
+eTV
+xUH
+pmd
+xKT
+qHp
+oDi
 aaf
 cLU
 crP
@@ -120109,21 +120430,21 @@ cLU
 cLU
 cLU
 cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-aaf
-cLU
+nLD
+dmw
+vUA
+tRc
+pMK
+tJT
+gfW
+bzO
+nLD
+pWD
+nKc
+dKo
+pqS
+bDQ
+jMk
 aaf
 cLU
 crP
@@ -120366,21 +120687,21 @@ cLU
 cLU
 cLU
 cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-aaf
-cLU
+nLD
+dti
+vUA
+klX
+bvO
+hZw
+mEc
+ihn
+xam
+wsP
+iMR
+gSL
+pAd
+rjQ
+aRC
 aaf
 cLU
 crP
@@ -120623,21 +120944,21 @@ cLU
 cLU
 cLU
 cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-aac
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-aaf
-cLU
+nLD
+vFG
+vuh
+vSZ
+byn
+eWD
+qXq
+lvK
+vVU
+rIN
+bzN
+oJj
+dul
+bDQ
+jMk
 aaf
 cLU
 crP
@@ -120880,21 +121201,21 @@ cLU
 cLU
 cLU
 cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-aaf
-cLU
+bzO
+bzO
+uoP
+mVl
+bwJ
+cSp
+nNr
+bzO
+lmu
+tXS
+bNu
+lNW
+qZa
+qHp
+oDi
 aaf
 cLU
 crP
@@ -121138,20 +121459,20 @@ cLU
 cLU
 cLU
 cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-aaf
-cLU
+bzO
+buR
+bzO
+rPX
+bkt
+oLF
+pnI
+mNA
+lGI
+bzO
+jQq
+vcz
+tQY
+oDi
 aaf
 cLU
 crP
@@ -121392,23 +121713,23 @@ crP
 crP
 crP
 crP
-crP
-crP
 cLU
 cLU
 cLU
 cLU
 cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-cLU
-aaf
-cLU
+bzO
+bzO
+bzO
+buR
+bzO
+qvM
+qvM
+bzO
+bzO
+bzO
+jMk
+jMk
 aaf
 cLU
 aaf
@@ -122428,7 +122749,7 @@ cLU
 cLU
 cLU
 cLU
-cLU
+aIv
 aaf
 aaf
 cLU
@@ -123684,7 +124005,7 @@ cLU
 cLU
 cLU
 cLU
-cLU
+aIv
 cLU
 cLU
 cLU
@@ -129338,7 +129659,7 @@ cLU
 cLU
 cLU
 cLU
-aIv
+cLU
 cLU
 cLU
 cLU

--- a/maps/exodus/exodus_unit_testing.dm
+++ b/maps/exodus/exodus_unit_testing.dm
@@ -38,8 +38,7 @@
 		/area/exodus/solar = NO_SCRUBBER|NO_VENT|NO_APC,
 		/area/exodus/storage/emergency = NO_SCRUBBER|NO_VENT,
 		/area/exodus/storage/emergency2 = NO_SCRUBBER|NO_VENT,
-		/area/ship/exodus_pod_engineering = NO_SCRUBBER|NO_VENT,
-		/area/ship/exodus_pod_research = NO_SCRUBBER
+		/area/ship/exodus_pod_engineering = NO_SCRUBBER|NO_VENT
 	)
 
 	area_coherency_test_exempt_areas = list(


### PR DESCRIPTION
## Description of changes
Replaces the Research Shuttle with a similar shuttle to that of the mining one. Minor modifications to the mining shuttle based on player experience

## Why and what will this PR improve
Brings the Research Shuttle on par with the mining one. Modifications made to the mining shuttle has been based on testing of the mining shuttle

## Authorship
Woodrat

## Changelog
:cl:
add: New research shuttle
add: Added 'radio_beacon' to mining shuttle
add: Geiger Counter to mining shuttle
tweak: Unlocked shuttle APC
del: Removed redundant console from mining and research dock  
/:cl: